### PR TITLE
Update required tools for Ubuntu 14 install

### DIFF
--- a/docs/Installation_on_Ubuntu_14.md
+++ b/docs/Installation_on_Ubuntu_14.md
@@ -103,6 +103,7 @@ We need to use Django's manage.py to initialise the app's database and create an
 
 	cd ..
 	python manage.py syncdb
+	python manage.py makemigrations
 	python manage.py migrate
 
 Stage the static files (type yes when prompted)

--- a/docs/Installation_on_Ubuntu_14.md
+++ b/docs/Installation_on_Ubuntu_14.md
@@ -19,9 +19,9 @@ If it isn't, install it:
 
 	apt-get install git
 
-Install python setup tools:
+Install required setup tools:
 
-	apt-get install python-setuptools libffi-dev
+	apt-get install gcc build-essential python-setuptools python-dev libffi-dev libssl-dev
 
 Make sure virtualenv is installed
 

--- a/sal.wsgi
+++ b/sal.wsgi
@@ -10,5 +10,5 @@ site.addsitedir(os.path.join(SAL_ENV_DIR, 'lib/python2.7/site-packages'))
 sys.path.append(SAL_ENV_DIR)
 sys.path.append(os.path.join(SAL_ENV_DIR, 'sal'))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "sal.settings")
-import django.core.handlers.wsgi
-application = django.core.handlers.wsgi.WSGIHandler()
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()

--- a/server/models.py
+++ b/server/models.py
@@ -236,7 +236,7 @@ class PendingAppleUpdate(models.Model):
         unique_together = ("machine", "update")
 
 class Plugin(models.Model):
-    name = models.CharField(max_length=255, unique=True)
+    name = models.CharField(max_length=512, unique=True)
     order = models.IntegerField()
     def __unicode__(self):
         return self.name

--- a/server/models.py
+++ b/server/models.py
@@ -236,7 +236,7 @@ class PendingAppleUpdate(models.Model):
         unique_together = ("machine", "update")
 
 class Plugin(models.Model):
-    name = models.CharField(max_length=512, unique=True)
+    name = models.CharField(max_length=255, unique=True)
     order = models.IntegerField()
     def __unicode__(self):
         return self.name


### PR DESCRIPTION
Installing these items before creating the virtualenv solves issues during migration.