### PR TITLE
Fixing 'Internal Server Error' on machine-specific inventory

### DIFF
--- a/inventory/views.py
+++ b/inventory/views.py
@@ -332,7 +332,7 @@ def machine_inventory(request, machine_id):
         inventory = InventoryItem.objects.filter(machine=machine).values('name', 'version', 'path', 'bundleid', 'bundlename').distinct()[start:end]
     else:
         inventory = InventoryItem.objects.filter(machine=machine).values('name', 'version', 'path', 'bundleid', 'bundlename')
-        inventory = unique_apps(inventory)[start:end]
+        inventory = unique_apps(inventory, 'dict')[start:end]
 
     if len(inventory) != 25:
         # we've not got 25 results, probably the last page


### PR DESCRIPTION
Fix for 'Internal Server Error' when clicking on 'Application Inventory' from a machine_detail page (i.e. for urls of the form '/inventory/machine/\<machineid\>/'). I'm seeing this error on Sal with MySQL 5.5.46 on Ubuntu 14.04, and this seems to fix it.