### PR TITLE
bump version number in Docs, more background

### DIFF
--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -35,10 +35,10 @@ $ docker run -d --name="sal"\
   -e DB_NAME=sal \
   -e DB_USER=admin \
   -e DB_PASS=password \
-  macadmins/sal:2.3.1.1
+  macadmins/sal:2.4.0.555
   ```
 
-This will allow you to log in with the username ``admin`` and the password ``pass`` (which I suggest you change!).
+This will allow you to log in with the username `admin` and the password `pass` (which I suggest you change!).
 
 ### Upgrading
 
@@ -55,9 +55,18 @@ $ docker run -d --name="sal" \
   -e DB_NAME=sal \
   -e DB_USER=admin \
   -e DB_PASS=password \
-  macadmins/sal:2.3.1.1
+  macadmins/sal:latest
   ```
+
+Again, that pulls the latest stable release by default, located on the Docker Hub image registry. Substitute the tagged version number you'd find [here](https://hub.docker.com/r/macadmins/sal/builds/) for 'latest' above to be explicit about what exact version you're upgrading to.
 
 ### Other options and plugins
 
 For other options that can be set via environment variables, and for how to use advanced options such as plugins, see the [repo on the Docker Hub](https://registry.hub.docker.com/u/macadmins/sal/).
+
+### Development / Testing Images / More Docker Background
+
+It is not recommended to run unreleased versions in production, but images built from the latest commit may be fetched by changing the last line of the run command, substituting `macadmins/sal:latest`, with `quay.io/macadmins/sal:latest`
+
+While not specific to Sal, [these slides](http://grahamgilbert.com/images/posts/2015-11-12/ImagrLab.pdf) on using Docker give an overview of a testing workflow, and the tools can be installed quickly by running [`autopkg install DockerToolbox`](https://github.com/autopkg/homebysix-recipes/blob/master/Docker/DockerToolbox.install.recipe).
+


### PR DESCRIPTION
Explicitly calls out location of docker image, adds reference section on quay.io for testing/dev