### PR TITLE
Update operating system plugin to sort correctly by version

### DIFF
--- a/server/plugins/operatingsystem/operatingsystem.py
+++ b/server/plugins/operatingsystem/operatingsystem.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 from yapsy.IPlugin import IPlugin
 from yapsy.PluginManager import PluginManager
 from django.template import loader, Context
@@ -17,9 +19,14 @@ class OperatingSystem(IPlugin):
         return 'List of operating system versions'
 
     def widget_content(self, page, machines=None, theid=None):
-        # The data is data is pulled from the database and passed to a template.
+        # The data is data is pulled from the database and passed to a
+        # template.
 
-        # There are three possible views we're going to be rendering to - front, bu_dashbaord and group_dashboard. If page is set to bu_dashboard, or group_dashboard, you will be passed a business_unit or machine_group id to use (mainly for linking to the right search).
+        # There are three possible views we're going to be rendering to -
+        # front, bu_dashbaord and group_dashboard. If page is set to
+        # bu_dashboard, or group_dashboard, you will be passed a
+        # business_unit or machine_group id to use (mainly for linking to
+        # the right search).
         if page == 'front':
             t = loader.get_template('operatingsystem/templates/os_front.html')
 
@@ -30,7 +37,12 @@ class OperatingSystem(IPlugin):
             t = loader.get_template('operatingsystem/templates/os_id.html')
 
         try:
-            os_info = machines.values('operating_system').annotate(count=Count('operating_system')).order_by('operating_system')
+            os_info = machines.values('operating_system').annotate(
+                count=Count('operating_system')).order_by(
+                    'operating_system')
+            os_info = sorted(
+                os_info,
+                key=lambda x: LooseVersion(x["operating_system"]))
         except:
             os_info = []
 
@@ -43,7 +55,10 @@ class OperatingSystem(IPlugin):
         return t.render(c)
 
     def filter_machines(self, machines, data):
-        # You will be passed a QuerySet of machines, you then need to perform some filtering based on the 'data' part of the url from the show_widget output. Just return your filtered list of machines and the page title.
+        # You will be passed a QuerySet of machines, you then need to
+        # perform some filtering based on the 'data' part of the url from
+        # the show_widget output. Just return your filtered list of
+        # machines and the page title.
 
         machines = machines.filter(operating_system__exact=data)
 


### PR DESCRIPTION
As discussed in Slack.

Now, the OS version plugin uses distutils.version.LooseVersion to sort the results of the os version query.

I couldn't get it to work using operator.itemgetter instead of a lambda.  ¯\_(ツ)_/¯