### PR TITLE
Fix single MG issue for BU machines query (fixes #83)

### DIFF
--- a/server/views.py
+++ b/server/views.py
@@ -557,7 +557,7 @@ def plugin_load(request, pluginName, page='front', theID=None):
         business_unit = get_object_or_404(BusinessUnit, pk=theID)
         machine_groups = MachineGroup.objects.filter(business_unit=business_unit).all()
 
-        machines = Machine.objects.filter(machine_group=machine_groups)
+        machines = Machine.objects.filter(machine_group__in=machine_groups)
 
     if page == 'group_dashboard':
         # only get machines from that group


### PR DESCRIPTION
The change updates the machines query to use the `in` operator rather than the exact operator used by default with the assignment operator.