### PR TITLE
Add VNC and SSH connection buttons to machine detail

### DIFF
--- a/docker/settings_import.py
+++ b/docker/settings_import.py
@@ -113,3 +113,12 @@ if BRUTE_PROTECT == True:
     # Max number of login attemts within the ``AXES_COOLOFF_TIME``
     AXES_LOGIN_FAILURE_LIMIT = BRUTE_LIMIT
     AXES_COOLOFF_TIME=BRUTE_COOLOFF
+
+# Read the SSH_ACCOUNT setting from env var
+try:
+    if getenv('DOCKER_SAL_SSH_ACCOUNT'):
+        SSH_ACCOUNT = getenv('DOCKER_SAL_SSH_ACCOUNT')
+    else:
+        SSH_ACCOUNT = None
+except:
+    SSH_ACCOUNT = None

--- a/server/templates/server/machine_detail.html
+++ b/server/templates/server/machine_detail.html
@@ -57,6 +57,14 @@ $( document ).ready(function() {
       <img src='https://km.support.apple.com.edgekey.net/kb/securedImage.jsp?configcode={{machine.serial|slice:"8:" }}&size=120x120'>
       <br>
       <h2 style="text-align:center">{{ machine.hostname }}</h2>
+      <span style="display: block; margin: 0px auto; text-align: center;" title="Remote Connections">
+					<button type="button" class="btn btn-default">
+						<span class="glyphicon glyphicon-log-in" aria-hidden="true"></span><a href="vnc://{{ ip_address }}"> VNC</a>
+					</button>
+					<button type="button" class="btn btn-default">
+						<span class="glyphicon glyphicon-log-in" aria-hidden="true"></span><a href="ssh://{% if ssh_account %}{{ ssh_account}}{% endif %}{{ ip_address }}"> SSH</a>
+					</button>
+      </span>
       <span style="display: block; margin: 0px auto; text-align: center;" title="Last report date">
         <b>Report</b> :: {{ machine.last_checkin|date:"Y-m-d H:i" }}
       </span>

--- a/server/views.py
+++ b/server/views.py
@@ -1422,7 +1422,20 @@ def machine_detail(request, machine_id):
 
     output = utils.orderPluginOutput(output)
 
-    c = {'user':user, 'machine_group': machine_group, 'business_unit': business_unit, 'report': report, 'install_results': install_results, 'removal_results': removal_results, 'machine': machine, 'facts':facts, 'conditions':conditions, 'ip_address':ip_address, 'uptime_enabled':uptime_enabled, 'uptime':uptime,'output':output }
+    c = {'user':user,
+         'machine_group': machine_group,
+         'business_unit': business_unit,
+         'report': report,
+         'install_results': install_results,
+         'removal_results': removal_results,
+         'machine': machine,
+         'facts': facts,
+         'conditions': conditions,
+         'ip_address': ip_address,
+         'uptime_enabled': uptime_enabled,
+         'uptime': uptime,
+         'output': output,
+         "ssh_account": settings.SSH_ACCOUNT}
     return render(request, 'server/machine_detail.html', c)
 
 # Edit Machine


### PR DESCRIPTION
I think our helpdesk would really appreciate having the ability to do a screen-sharing session to a machine found through Sal. This PR puts a couple of bootstrap buttons on the machine_detail view. The buttons are just links to the machine's IP address; one for vnc, one for ssh.

I don't feel that this is entirely ready to merge. A couple of issues:

1. I played around with putting the buttons in their own panel. I tried to split the row with the machine image, putting the buttons vertically stacked to the right of the image. I tried doing the same with the hostname, report time on the left, and the buttons on the right. I'm not familiar enough with Sal's layout to really get a more compact layout, so I left it like this. Therefore, if you think there's a better location for it; by all means design it how you want.
2. At least on Chrome and Safari which I tested, the vnc link opens Apple screen sharing (which I assume negotiates up to the more secure apple remote desktop protocol) and prompts for both a _username_ and a password. However, the ssh link opens terminal, which assumes you want to use the currently-logged-in console user as the user. In some environments, with users bound to the directory and access permissions set appropriately, this will be fine. However, I have certainly also seen environments where a generic admin account is placed on every machine, and the user initiating the connection would not be able to use this button. I added (I think) a Docker environment variable that should optionally insert an account name as part of the SSH link URL. I'm not super familiar with how the docker/settings_import module works with passed environment variables, and I can't figure out how to set it up to test it easily. Just stopping and starting the container doesn't seem to get the extra env variable in (`DOCKER_SAL_SSH_ACCOUNT`). So, if I did this wrong, or you want me to quit fooling around and figure out how to test this, let me know.