### PR TITLE
Remote connection machine plugin

### DIFF
--- a/docker/settings_import.py
+++ b/docker/settings_import.py
@@ -113,3 +113,13 @@ if BRUTE_PROTECT == True:
     # Max number of login attemts within the ``AXES_COOLOFF_TIME``
     AXES_LOGIN_FAILURE_LIMIT = BRUTE_LIMIT
     AXES_COOLOFF_TIME=BRUTE_COOLOFF
+
+
+# Read the SSH_ACCOUNT setting from env var
+try:
+    if getenv('DOCKER_SAL_SSH_ACCOUNT'):
+        SSH_ACCOUNT = getenv('DOCKER_SAL_SSH_ACCOUNT')
+    else:
+        SSH_ACCOUNT = None
+except:
+    SSH_ACCOUNT = None

--- a/server/plugins/machine_detail_remote_connection/machine_detail_remote_connection.py
+++ b/server/plugins/machine_detail_remote_connection/machine_detail_remote_connection.py
@@ -42,7 +42,7 @@ class RemoteConnection(IPlugin):
             except Machine.DoesNotExist:
                 pass
 
-        if hasattr(settings,  "SSH_ACCOUNT"):
+        if hasattr(settings,  "SSH_ACCOUNT") and settings.SSH_ACCOUNT:
             ssh_account = settings.SSH_ACCOUNT + "@"
         else:
             ssh_account = ""

--- a/server/plugins/machine_detail_remote_connection/machine_detail_remote_connection.py
+++ b/server/plugins/machine_detail_remote_connection/machine_detail_remote_connection.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+"""Machine detail plugin to allow easy VNC or SSH connections."""
+
+
+from django.conf import settings
+from django.db.models import Count
+from django.shortcuts import get_object_or_404
+from django.template import loader, Context
+from yapsy.IPlugin import IPlugin
+from yapsy.PluginManager import PluginManager
+
+from server.models import *
+import server.utils as utils
+
+
+class RemoteConnection(IPlugin):
+
+    def plugin_type(self):
+        return "machine_detail"
+
+    def widget_width(self):
+        return 4
+
+    def get_description(self):
+        return "Initiate VNC or SSH connections from a machine detail page."
+
+    def widget_content(self, page, machines=None, theid=None):
+        # Rename class keyword argument to be more accurate, since it will
+        # only be a single machine.
+        machine = machines
+        template = loader.get_template(
+            "machine_detail_remote_connection/templates/"
+            "machine_detail_remote_connection.html")
+
+        ip_address = ""
+        if machine.conditions.count() > 0:
+            try:
+                ip_addresses = machine.conditions.get(
+                    condition_name="ipv4_address").condition_data
+                # Machines may have multiple IPs. Just use the first.
+                ip_address = ip_addresses.split(",")[0]
+            except Machine.DoesNotExist:
+                pass
+
+        if hasattr(settings,  "SSH_ACCOUNT"):
+            ssh_account = settings.SSH_ACCOUNT + "@"
+        else:
+            ssh_account = ""
+
+        context = Context({
+            "title": "Remote Connection",
+            "ssh_account": ssh_account.replace("@", ""),
+            "vnc_url": "vnc://{}{}".format(ssh_account, ip_address),
+            "ssh_url": "ssh://{}{}".format(ssh_account, ip_address),})
+
+        return template.render(context)

--- a/server/plugins/machine_detail_remote_connection/machine_detail_remote_connection.py
+++ b/server/plugins/machine_detail_remote_connection/machine_detail_remote_connection.py
@@ -3,14 +3,10 @@
 
 
 from django.conf import settings
-from django.db.models import Count
-from django.shortcuts import get_object_or_404
 from django.template import loader, Context
 from yapsy.IPlugin import IPlugin
-from yapsy.PluginManager import PluginManager
 
-from server.models import *
-import server.utils as utils
+from server.models import Machine
 
 
 class RemoteConnection(IPlugin):
@@ -42,7 +38,7 @@ class RemoteConnection(IPlugin):
             except Machine.DoesNotExist:
                 pass
 
-        if hasattr(settings,  "SSH_ACCOUNT") and settings.SSH_ACCOUNT:
+        if hasattr(settings, "SSH_ACCOUNT") and settings.SSH_ACCOUNT:
             ssh_account = settings.SSH_ACCOUNT + "@"
         else:
             ssh_account = ""

--- a/server/plugins/machine_detail_remote_connection/machine_detail_remote_connection.yapsy-plugin
+++ b/server/plugins/machine_detail_remote_connection/machine_detail_remote_connection.yapsy-plugin
@@ -1,0 +1,8 @@
+[Core]
+Name = RemoteConnection
+Module = machine_detail_remote_connection
+
+[Documentation]
+Author = Shea G Craig
+Version = 1.0
+Website = http://sheagcraig.com

--- a/server/plugins/machine_detail_remote_connection/templates/machine_detail_remote_connection.html
+++ b/server/plugins/machine_detail_remote_connection/templates/machine_detail_remote_connection.html
@@ -8,7 +8,7 @@
 			<button type="button" class="btn btn-default">
 				<span class="glyphicon glyphicon-log-in" aria-hidden="true"></span><a href="{{ ssh_url }}"> SSH</a>
 			</button>
-			<span style="padding: 6px 12px;"><a class="btn btn-info">Account</a> {% if ssh_account %}{{ ssh_account }}{% else %}your username{% endif %}</span>
+			{% if ssh_account %}<span style="padding: 6px 12px;"><a class="btn btn-info">Account</a> {{ ssh_account }}</span>{% endif %}
     </dl>
   </div>
 </div>

--- a/server/plugins/machine_detail_remote_connection/templates/machine_detail_remote_connection.html
+++ b/server/plugins/machine_detail_remote_connection/templates/machine_detail_remote_connection.html
@@ -1,0 +1,14 @@
+<div class="panel panel-default">
+  <div class="panel-body">
+    <dl class="dl-horizontal">
+      <legend><h5 class"text-uppercase">Remote Connections</h5></legend>
+			<button type="button" class="btn btn-default">
+				<span class="glyphicon glyphicon-log-in" aria-hidden="true"></span><a href="{{ vnc_url }}"> VNC</a>
+			</button>
+			<button type="button" class="btn btn-default">
+				<span class="glyphicon glyphicon-log-in" aria-hidden="true"></span><a href="{{ ssh_url }}"> SSH</a>
+			</button>
+			<span style="padding: 6px 12px;"><a class="btn btn-info">Account</a> {% if ssh_account %}{{ ssh_account }}{% else %}your username{% endif %}</span>
+    </dl>
+  </div>
+</div>


### PR DESCRIPTION
Adds a machine detail plugin to open a vnc or ssh connection. As the open ssh handler uses the username of the current console user, also adds a Docker environment variable to specify another account name, globally. But don't do that.