### PR TITLE
Specify page type of `machine_detail` for machine_detail utility call

### DIFF
--- a/server/views.py
+++ b/server/views.py
@@ -1420,7 +1420,7 @@ def machine_detail(request, machine_id):
                 output.append(data)
                 break
 
-    output = utils.orderPluginOutput(output)
+    output = utils.orderPluginOutput(output, page="machine_detail")
 
     c = {'user':user, 'machine_group': machine_group, 'business_unit': business_unit, 'report': report, 'install_results': install_results, 'removal_results': removal_results, 'machine': machine, 'facts':facts, 'conditions':conditions, 'ip_address':ip_address, 'uptime_enabled':uptime_enabled, 'uptime':uptime,'output':output }
     return render(request, 'server/machine_detail.html', c)


### PR DESCRIPTION
It seems that the `machine_detail` view had an oversight where it didn't specify the page type (an optional kwarg on `utils.orderPluginOutput`) which resulted being mis-categorized as the `front` page type.