### PR TITLE
Feature inventory exclusions pref

### DIFF
--- a/docker/settings_import.py
+++ b/docker/settings_import.py
@@ -131,10 +131,7 @@ try:
 except:
     SSH_ACCOUNT = None
 
-try:
-    if getenv('DOCKER_SAL_INVENTORY_EXCLUSIONS'):
-        INVENTORY_EXCLUSIONS = getenv('DOCKER_SAL_INVENTORY_EXCLUSIONS')
-    else:
-        INVENTORY_EXCLUSIONS = None
-except:
-    INVENTORY_EXCLUSIONS = None
+# If an exclusion pattern is provided as an env, use it. Otherwise,
+# just use the default specified in system_settings.
+if getenv('DOCKER_SAL_INVENTORY_EXCLUSIONS'):
+    INVENTORY_EXCLUSIONS = getenv('DOCKER_SAL_INVENTORY_EXCLUSIONS')

--- a/docker/settings_import.py
+++ b/docker/settings_import.py
@@ -122,7 +122,6 @@ if BRUTE_PROTECT == True:
     AXES_LOGIN_FAILURE_LIMIT = BRUTE_LIMIT
     AXES_COOLOFF_TIME=BRUTE_COOLOFF
 
-
 # Read the SSH_ACCOUNT setting from env var
 try:
     if getenv('DOCKER_SAL_SSH_ACCOUNT'):
@@ -131,3 +130,11 @@ try:
         SSH_ACCOUNT = None
 except:
     SSH_ACCOUNT = None
+
+try:
+    if getenv('DOCKER_SAL_INVENTORY_EXCLUSIONS'):
+        INVENTORY_EXCLUSIONS = getenv('DOCKER_SAL_INVENTORY_EXCLUSIONS')
+    else:
+        INVENTORY_EXCLUSIONS = None
+except:
+    INVENTORY_EXCLUSIONS = None

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1,9 +1,9 @@
 # standard library
+from datetime import datetime
+from urllib import quote
 import hashlib
 import plistlib
-from datetime import datetime
-from django.utils import timezone
-from urllib import quote
+import re
 
 # third-party
 import unicodecsv as csv
@@ -16,6 +16,7 @@ from django.http import (HttpResponse, HttpResponseNotFound,
                          HttpResponseBadRequest)
 from django.shortcuts import get_object_or_404, render_to_response
 from django.template import RequestContext
+from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import DetailView, View
 # TODO: For new django-datatables-view interface
@@ -243,7 +244,18 @@ class ApplicationListView(LegacyDatatableView, GroupMixin):
         # An empty pattern, i.e. r'', will exclude ALL apps, which is not
         # desired.
         if exclusion_pattern:
-            queryset = queryset.exclude(bundleid__regex=exclusion_pattern)
+            # It makes sense to just try to exclude in a try/except and
+            # handle django.db.DataError. For some reason that exception
+            # never gets caught, so we test to see if re.compile works.
+            try:
+                pattern = re.compile(exclusion_pattern)
+            except re.error:
+                # It would be nice to log the message from this
+                # exception so the admin would know it's broken and why.
+                # However, the error never gets printed.
+                pattern = None
+            if pattern:
+                queryset = queryset.exclude(bundleid__regex=exclusion_pattern)
 
         return queryset
 

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -235,17 +235,15 @@ class ApplicationListView(LegacyDatatableView, GroupMixin):
     def get_queryset(self):
         queryset = self.filter_queryset_by_group(self.model.objects).distinct()
 
-        # For now, remove cruft from results (until we can add prefs):
+        if hasattr(settings, "INVENTORY_EXCLUSIONS"):
+            exclusion_pattern = settings.INVENTORY_EXCLUSIONS
+        else:
+            exclusion_pattern = r''
 
-        # Virtualization proxied apps
-        crufty_bundles = ["com.vmware.proxyApp", "com.parallels.winapp"]
-        crufty_pattern = r"({}).*".format("|".join(crufty_bundles))
-
-        # Apple apps that are not generally used by users.
-        apple_cruft_pattern = (r'com.apple.(?!iPhoto)(?!iWork)(?!Aperture)'
-            r'(?!iDVD)(?!garageband)(?!iMovieApp)(?!Server)(?!dt\.Xcode).*')
-        queryset = queryset.exclude(bundleid__regex=crufty_pattern)
-        # queryset = queryset.exclude(bundleid__regex=apple_cruft_pattern)
+        # An empty pattern, i.e. r'', will exclude ALL apps, which is not
+        # desired.
+        if exclusion_pattern:
+            queryset = queryset.exclude(bundleid__regex=exclusion_pattern)
 
         return queryset
 

--- a/sal/system_settings.py
+++ b/sal/system_settings.py
@@ -81,6 +81,24 @@ EXCLUDED_FACTS = {
 EXCLUDED_CONDITIONS = {
     # 'some_condition',
 }
+
+# Regular expression pattern to use to exclude applications by bundle
+# ID from Inventory views.
+crufty_bundles = ["com.vmware.proxyApp", "com.parallels.winapp"]
+# Just to avoid the potential for mistakes, build a pattern from the
+# list above.
+INVENTORY_EXCLUSIONS = r"({}).*".format("|".join(crufty_bundles))
+# # Virtualization proxied apps
+
+# The following  pattern is an example of a negative lookahead
+# assertion... It matches, and thus excludes, all apps that have a bundle
+# ID that starts with 'com.apple' and DOES NOT include "iPhoto", "iWork",
+# etc.  Effectively, this means exclude all Apple apps EXCEPT those
+# listed. Make sure to OR this with any other exclusions desired.
+
+# (r'com.apple.(?!iPhoto)(?!iWork)(?!Aperture)'
+# r'(?!iDVD)(?!garageband)(?!iMovieApp)(?!Server)(?!dt\.Xcode).*'))
+
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
This PR follows through on my desire to add a feature to the Inventory views to allow Admins to customize what bundle identifiers are excluded from the inventory views (they're still included in the DB).

A conditional exclude is run if a regex is configured in settings.py, system_settings.py, or the docker environment, and by default, the existing exclusions of Parallels and Fusion virtual apps are maintained.

Handling is in place for invalid regexes as well. (regexen?)

Once you indicate that this is okay to (eventually) merge, I'll update the wiki with example settings that show how to use this more broadly than the default (and document the defaults as well).

Outstanding issues:

# Issue number 1
I'm confused about the `docker/settings_import.py` idiom of wrapping many of the getenv calls in a try/except block. `os.getenv` returns either the string value of the environment variable or `None`, much like `dict.get`, so as long as each "import" has an `if getenv("<WHATEVER>"):`, it seems like it should be fine. Also, since most if not all of these settings have defaults specified in `system_settings.py`, there's no need to provide a default value. I can see probably how this propogated; the values that get cast to `int` need it, and then those blocks just got copied and pasted as new settings were added.

Arguably, explicit is better than implicit, but it also means there's duplication of the literal default values between the two or three settings files.˙

This isn't really the appropriate branch to do this work, but if there's no real way for these to fail, I can refactor `docker/settings_import.py` and submit another PR to make this a lot more concise and eliminate the duplication.

# Issue number 2
For some reason I couldn't take the more direct route and try to catch django.db.DataError when testing for an invalid exclusion pattern. That's definitely the exception that gets raised, but I couldn't get it to catch that. Equally confusing, I wanted to just `print` a message to the logs so admins would see a message saying they had provided an invalid pattern, but I couldn't get it to ever print anything. You can see in the comments for the new code where this takes place if there's something stupid that I'm overlooking.