### PR TITLE
Add an ARD computer information field machine detail plugin

### DIFF
--- a/server/plugins/machine_detail_ard_info/ard_info.py
+++ b/server/plugins/machine_detail_ard_info/ard_info.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+
+
+from django.template import loader, Context
+from yapsy.IPlugin import IPlugin
+
+from server.models import PluginScriptRow
+
+
+class ARDInfo(IPlugin):
+    name = "ARD Info"
+
+    def widget_width(self):
+        return 4
+
+    def plugin_type(self):
+        return 'machine_detail'
+
+    def get_description(self):
+        return "Apple Remote Desktop's Computer Information Fields"
+
+    def widget_content(self, page, machine=None, theid=None):
+        template = loader.get_template(
+            "machine_detail_ard_info/templates/ard_info.html")
+
+        ard_info = {}
+
+        for i in xrange(1, 5):
+            key = 'ARD_Info_{}'.format(i)
+            row = PluginScriptRow.objects.filter(
+                submission__machine=machine,
+                submission__plugin='ARD_Info',
+                pluginscript_name=key)
+
+            try:
+                val = row.first().pluginscript_data
+            except:
+                val = ""
+            ard_info[key] = val
+
+        c = Context({
+            "title": self.get_description(),
+            "data": ard_info,
+            "theid": theid,
+            "page": page})
+
+        return template.render(c)

--- a/server/plugins/machine_detail_ard_info/ard_info.yapsy-plugin
+++ b/server/plugins/machine_detail_ard_info/ard_info.yapsy-plugin
@@ -1,0 +1,8 @@
+[Core]
+Name = ARDInfo
+Module = ard_info
+
+[Documentation]
+Author = Shea Craig
+Version = 1.0
+Website = http://www.sheagcraig.com

--- a/server/plugins/machine_detail_ard_info/scripts/ard_info.py
+++ b/server/plugins/machine_detail_ard_info/scripts/ard_info.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+
+
+import os
+import sys
+
+sys.path.append("/usr/local/munki/munkilib")
+import FoundationPlist
+
+
+RESULTS_PATH = "/usr/local/sal/plugin_results.plist"
+
+
+def main():
+    ard_path = "/Library/Preferences/com.apple.RemoteDesktop.plist"
+    if os.path.exists(ard_path):
+        ard_prefs = FoundationPlist.readPlist(ard_path)
+    else:
+        ard_prefs = {}
+
+    sal_result_key = "ARD_Info_{}"
+    prefs_key_prefix = "Text{}"
+
+    data  = {
+        sal_result_key.format(i): ard_prefs.get(prefs_key_prefix.format(i), "")
+        for i in xrange(1, 5)}
+
+    formatted_results = {
+        "plugin": "ARD_Info",
+        "historical": False,
+        "data": data}
+
+    if os.path.exists(RESULTS_PATH):
+        plugin_results = FoundationPlist.readPlist(RESULTS_PATH)
+    else:
+        plugin_results = []
+
+    plugin_results.append(formatted_results)
+
+    FoundationPlist.writePlist(plugin_results, RESULTS_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/plugins/machine_detail_ard_info/templates/ard_info.html
+++ b/server/plugins/machine_detail_ard_info/templates/ard_info.html
@@ -1,0 +1,15 @@
+<div class="panel panel-default">
+  <div class="panel-body">
+    <dl class="dl-horizontal">
+      <legend><h5 class"text-uppercase">Apple Remote Desktop Computer Information</h5></legend>
+      <dt>Text 1</dt>
+      <dd>{{ data.ARD_Info_1 }}</dd>
+      <dt>Text 2</dt>
+      <dd>{{ data.ARD_Info_2 }}</dd>
+      <dt>Text 3</dt>
+      <dd>{{ data.ARD_Info_3 }}</dd>
+      <dt>Text 4</dt>
+      <dd>{{ data.ARD_Info_4 }}</dd>
+    </dl>
+  </div>
+</div>


### PR DESCRIPTION
Does just what it says.

If for some reason you wanted to do a search across the data in these fields, I don't know if search can look through plugin script results, but I don't need that.