### PR TITLE
Fix deprecated future tag import

### DIFF
--- a/templates/registration/password_change_done.html
+++ b/templates/registration/password_change_done.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load url from future %}
 {% load bootstrap3 }
 {% block content %}
 

--- a/templates/registration/password_change_form.html
+++ b/templates/registration/password_change_form.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load url from future %}
 {% load bootstap3 }
 {% block content %}
         <div class="row">


### PR DESCRIPTION
Django 1.10 drops the need to import url from future, since it is the future ;)

This should solve #102. (Tested on my server)