### PR TITLE
Provide default values for database host and user in docker/settings.py

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -8,6 +8,8 @@ This Docker image runs [Sal](https://github.com/salopensource/sal). The containe
 Several options, such as the timezone and admin password are customizable using environment variables.
 
 * ``ADMIN_PASS``: The default admin's password. This is only set if there are no other superusers, so if you choose your own admin username and password later on, this won't be created.
+* ``DB_HOST``: Sets the hostname of the database sal will connect to. Defaults to ``db``.
+* ``DB_PORT``: Sets the port sal will connect to on the host specified in ``DB_HOST``. Defaults to ``5432``.
 * ``DOCKER_SAL_DISPLAY_NAME``: This sets the name that appears in the title bar of the window. Defaults to ``Sal``.
 * ``DOCKER_SAL_TZ``: The desired [timezone](http://en.wikipedia.org/wiki/List_of_tz_database_time_zones). Defaults to ``Europe/London``.
 * ``DOCKER_SAL_ADMINS``: The admin user's details. Defaults to ``Docker User, docker@localhost``.

--- a/docker/settings.py
+++ b/docker/settings.py
@@ -28,13 +28,18 @@ if os.environ.has_key('MEMCACHED_PORT_11211_TCP_ADDR'):
 host = None
 port = None
 
-if os.environ.has_key('DB_HOST'):
-    host = os.environ.get('DB_HOST')
-    port = os.environ.get('DB_PORT')
+if os.environ.has_key('DB_USER'):
+    if os.environ.has_key('DB_HOST'):
+        host = os.environ.get('DB_HOST')
+        port = os.environ.get('DB_PORT', '5432')
 
-elif os.environ.has_key('DB_PORT_5432_TCP_ADDR'):
-    host = os.environ.get('DB_PORT_5432_TCP_ADDR')
-    port = os.environ.get('DB_PORT_5432_TCP_PORT', '5432')
+    elif os.environ.has_key('DB_PORT_5432_TCP_ADDR'):
+        host = os.environ.get('DB_PORT_5432_TCP_ADDR')
+        port = os.environ.get('DB_PORT_5432_TCP_PORT', '5432')
+
+    else:
+        host = 'db'
+        port = '5432'
 
 if host and port:
     DATABASES = {


### PR DESCRIPTION
If the ``DB_USER`` environment variable is specified, but ``DB_HOST`` isn't, the ``host`` and ``port`` variables could end up being ``None``, resulting in Django attempting to use the SQLite database defined earlier in docker/settings.py. See [this segment](https://github.com/salopensource/sal/blob/a4a026443d639c926c091566451e07795eb716cf/docker/settings.py#L28-L37).

If the ``DB_USER`` environment variable is set, should we assume that we don't want to use SQLite? If ``DB_HOST`` and ``DB_PORT`` aren't specified, they are given default values of ``db`` and ``5432``, respectively.

Also mentions that ``DB_USER`` and ``DB_PORT`` are valid environment variables docker/README.md.