### PR TITLE
Added hostname to page title for tab-thirsty folks.

### DIFF
--- a/server/templates/server/machine_detail.html
+++ b/server/templates/server/machine_detail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load dashboard_extras %}
-
+{% block title %}Sal - {{ machine.hostname }}{% endblock %}
 {% block script %}
 <script>
 


### PR DESCRIPTION
Allows users with a variety of Sal machine detail pages open to identify machine from page title.