### PR TITLE
Friendly machine model without internet 

### DIFF
--- a/server/views.py
+++ b/server/views.py
@@ -1950,7 +1950,10 @@ def checkin(request):
         machine.os_family = report_data['os_family']
 
     if not machine.machine_model_friendly:
-        machine.machine_model_friendly = utils.friendly_machine_model(machine)
+        try:
+            machine.machine_model_friendly = utils.friendly_machine_model(machine)
+        except:
+            machine.machine_model_friendly = machine.machine_model
 
     if deployed_on_checkin is True:
         machine.deployed = True


### PR DESCRIPTION
This is to fix an issue I'm seeing when Sal server has no internet connection. 

I'm finding that the exceptions thrown [here](https://github.com/salopensource/sal/blob/master/server/utils.py#L540-L563) are causing new machines from getting enrolled. 

There is probably a better way to do this but its the best I can come up with. 
