### PR TITLE
fix: Add xprotect desc to the plugin

### DIFF
--- a/server/plugins/xprotectversion/xprotectversion.py
+++ b/server/plugins/xprotectversion/xprotectversion.py
@@ -11,6 +11,9 @@ class XprotectVersion(IPlugin):
     def widget_width(self):
         return 4
 
+    def get_description(self):
+        return 'Xprotect version'
+
     def widget_content(self, page, machines=None, theid=None):
 
 


### PR DESCRIPTION
The description for the xprotect plugin was missing.