### PR TITLE
Fix for licenses/models.py FieldError

### DIFF
--- a/licenses/models.py
+++ b/licenses/models.py
@@ -31,7 +31,7 @@ class License(models.Model):
             items = items.filter(application__bundleid__exact=self.inventory_bundleid)
         if self.inventory_bundlename:
             items = items.filter(
-                bundlename__exact=self.inventory_bundlename)
+                application__bundlename__exact=self.inventory_bundlename)
         if self.inventory_path:
             items = items.filter(path__exact=self.inventory_path)
         if self.business_unit:


### PR DESCRIPTION
Fixes an issue with the licenses index page when bundlename is defined for a license item:
`FieldError: Cannot resolve keyword 'bundlename' into field. Choices are: application, application_id, id, machine, machine_id, path, version`

(to replicate: create a license item and enter any text for the bundlename, then attempt to view the licenses index page)