### PR TITLE
One more fix for friendly_machine_model

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -550,7 +550,7 @@ def friendly_machine_model(machine):
             output = name['machine_model_friendly']
             break
         
-    if output is None and not machine.serial.startswith('VM'):
+    if not output and not machine.serial.startswith('VM'):
         if len(machine.serial) == 12:
             serial_snippet = machine.serial[-4:]
         else:


### PR DESCRIPTION
Change "if output is None" check to "if not output" so that clearing the machine_model_friendly field will trigger a new look up (an empty string is not None, but both an empty string and None are "falsey")