### PR TITLE
Switches line 40 and 41 to resolve Serial = None issue

### DIFF
--- a/server/plugins/cryptstatus/cryptstatus.py
+++ b/server/plugins/cryptstatus/cryptstatus.py
@@ -37,8 +37,8 @@ class CryptStatus(IPlugin):
         output = {}
         date_escrowed = None
         escrowed = None
+	if crypt_url:
         request_url = crypt_url + '/verify/'+ serial + '/recovery_key/'
-        if crypt_url:
             try:
                 r = requests.get(request_url)
                 if r.status_code == requests.codes.ok:


### PR DESCRIPTION
Resolves this issue:

```[24/Aug/2017 15:57:34] ERROR [django.request:124] Internal Server Error: /id_pluginload/CryptStatus/machine_detail/96/
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/exception.py", line 39, in inner
    response = get_response(request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/contrib/auth/decorators.py", line 23, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/home/docker/sal/server/views.py", line 578, in plugin_load
    html = plugin.plugin_object.widget_content(page, machines, theID)
  File "/home/docker/sal/server/plugins/cryptstatus/cryptstatus.py", line 37, in widget_content
    request_url = crypt_url + '/verify/'+ serial + '/recovery_key/'
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'```

Was mentioned to drop line 40 below the if statement