### PR TITLE
removed .count() from filter_machines in uptime.py

### DIFF
--- a/server/plugins/uptime/uptime.py
+++ b/server/plugins/uptime/uptime.py
@@ -85,7 +85,7 @@ class Uptime(IPlugin):
             not_alert_range = []
             for i in range(0,90):
                 not_alert_range.append(str(i))
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Uptime', pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='UptimeDays').exclude(pluginscriptsubmission__pluginscriptrow__pluginscript_data__in=not_alert_range).count()
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Uptime', pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='UptimeDays').exclude(pluginscriptsubmission__pluginscriptrow__pluginscript_data__in=not_alert_range)
             title = 'Machines with more than 90 days of uptime'
 
         else:


### PR DESCRIPTION
This filter should return a list of machines, not a count. Looks like a cp mistake :).

Eg error cause by this:

`[03/Nov/2017 21:33:15] ERROR [django.request:124] Internal Server Error: /tableajax/Uptime/alert/
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/exception.py", line 39, in inner
    response = get_response(request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/contrib/auth/decorators.py", line 23, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/home/docker/sal/server/views.py", line 443, in tableajax
    searched_machines = machines.order_by(order_string)
AttributeError: 'int' object has no attribute 'order_by'`