### PR TITLE
fix: Enable plugins by name

### DIFF
--- a/server/templates/server/machine_detail_plugins.html
+++ b/server/templates/server/machine_detail_plugins.html
@@ -101,7 +101,7 @@
                             <td>
                                 {{ plugin.os_families|flatten_and_sort_list}}
                             </td>
-                            <td><a href="{% url 'machine_detail_plugin_enable' plugin %}" title="Enable Plugin" class="btn btn-mini btn-info pull-right"><i class="fa fa-check"></i></a></td>
+                            <td><a href="{% url 'machine_detail_plugin_enable' plugin.name %}" title="Enable Plugin" class="btn btn-mini btn-info pull-right"><i class="fa fa-check"></i></a></td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/server/templates/server/plugins.html
+++ b/server/templates/server/plugins.html
@@ -92,7 +92,7 @@
                         {% for plugin in disabled_plugins %}
                         <tr>
                             <td>{{ plugin.name }}</td>
-                            <td><a href="{% url 'plugin_enable' plugin %}" title="Enable Plugin" class="btn btn-mini btn-info pull-right"><i class="fa fa-check"></i></a></td>
+                            <td><a href="{% url 'plugin_enable' plugin.name %}" title="Enable Plugin" class="btn btn-mini btn-info pull-right"><i class="fa fa-check"></i></a></td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/server/templates/server/reports.html
+++ b/server/templates/server/reports.html
@@ -78,7 +78,7 @@
                         {% for plugin in disabled_plugins %}
                         <tr>
                             <td>{{ plugin.name }}</td>
-                            <td><a href="{% url 'settings_report_enable' plugin %}" title="Enable Report" class="btn btn-mini btn-info pull-right"><i class="fa fa-check"></i></a></td>
+                            <td><a href="{% url 'settings_report_enable' plugin.name %}" title="Enable Report" class="btn btn-mini btn-info pull-right"><i class="fa fa-check"></i></a></td>
                         </tr>
                         {% endfor %}
                     </tbody>

--- a/server/views.py
+++ b/server/views.py
@@ -1666,24 +1666,23 @@ def machine_detail_plugin_enable(request, plugin_name):
     # only do this if there isn't a plugin already with the name
     try:
         plugin = MachineDetailPlugin.objects.get(name=plugin_name)
-    except Plugin.DoesNotExist:
-        enabled_plugins = Plugin.objects.all()
+    except MachineDetailPlugin.DoesNotExist:
+        enabled_plugins = MachineDetailPlugin.objects.all()
         # Build the manager
         manager = PluginManager()
         # Tell it the default place(s) where to find plugins
         manager.setPluginPlaces([settings.PLUGIN_DIR, os.path.join(settings.PROJECT_DIR, 'server/plugins')])
         # Load all plugins
         manager.collectPlugins()
-        enabled_plugins = apps.get_model("server", "MachineDetailPlugin")
-        for item in enabled_plugins.objects.all():
-            default_families = ['Darwin', 'Windows', 'Linux']
-            for plugin in manager.getAllPlugins():
-                if plugin.name == item.name:
 
-                    try:
-                        supported_os_families = plugin.plugin_object.supported_os_families()
-                    except:
-                        supported_os_families = default_families
+        default_families = ['Darwin', 'Windows', 'Linux']
+        for plugin in manager.getAllPlugins():
+            if plugin.name == plugin_name:
+
+                try:
+                    supported_os_families = plugin.plugin_object.supported_os_families()
+                except:
+                    supported_os_families = default_families
         plugin = MachineDetailPlugin(name=plugin_name, order=utils.UniquePluginOrder(plugin_type='machine_detail'), os_families=utils.flatten_and_sort_list(supported_os_families))
         plugin.save()
     return redirect('settings_machine_detail_plugins')


### PR DESCRIPTION
This partially fixes a regression that was introduced with [v3.2.5](https://github.com/salopensource/sal/compare/3.2.4...3.2.5). 

This can be replicated by going to http://sal/settings/plugins/ and clicking the enable checkbox on any disabled plugin. Instead of enabling the plugin you will get a stack-trace if Debug is enable or a silent failure. 

Regular plugins 100% fixed
Report plugins 100% fixed
Machine detail plugins still broken.

An Machine detail plugins issue exists someplace in https://github.com/salopensource/sal/blob/44ab8058a1db3423748393e50a23c3c3eb7632ca/server/views.py#L1664-L1689 (I think?) that is causing the following error

```bash
Environment:


Request Method: GET
Request URL: http://localhost:8000/settings/plugins/machinedetail/enable/RemoteConnection/

Django Version: 1.10
Python Version: 2.7.10
Installed Applications:
('django.contrib.auth',
 'django.contrib.contenttypes',
 'django.contrib.sessions',
 'django.contrib.sites',
 'django.contrib.messages',
 'django.contrib.staticfiles',
 'django.contrib.admin',
 'django.contrib.admindocs',
 'sal',
 'server',
 'api',
 'catalog',
 'inventory',
 'licenses',
 'bootstrap3',
 'watson',
 'datatableview',
 'search')
Installed Middleware:
('django.middleware.security.SecurityMiddleware',
 'django.contrib.sessions.middleware.SessionMiddleware',
 'django.middleware.common.CommonMiddleware',
 'django.middleware.csrf.CsrfViewMiddleware',
 'django.contrib.auth.middleware.AuthenticationMiddleware',
 'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
 'django.contrib.messages.middleware.MessageMiddleware',
 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 'server.middleware.AddToBU.AddToBU',
 'search.current_user.CurrentUserMiddleware')



Traceback:

File "/Users/clayton.burlison/Documents/src/others/sal/sal_env/lib/python2.7/site-packages/django/core/handlers/exception.py" in inner
  39.             response = get_response(request)

File "/Users/clayton.burlison/Documents/src/others/sal/sal_env/lib/python2.7/site-packages/django/core/handlers/base.py" in _legacy_get_response
  249.             response = self._get_response(request)

File "/Users/clayton.burlison/Documents/src/others/sal/sal_env/lib/python2.7/site-packages/django/core/handlers/base.py" in _get_response
  187.                 response = self.process_exception_by_middleware(e, request)

File "/Users/clayton.burlison/Documents/src/others/sal/sal_env/lib/python2.7/site-packages/django/core/handlers/base.py" in _get_response
  185.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/Users/clayton.burlison/Documents/src/others/sal/sal_env/lib/python2.7/site-packages/django/contrib/auth/decorators.py" in _wrapped_view
  23.                 return view_func(request, *args, **kwargs)

File "/Users/clayton.burlison/Documents/src/others/sal/server/views.py" in machine_detail_plugin_enable
  1668.         plugin = MachineDetailPlugin.objects.get(name=plugin_name)

File "/Users/clayton.burlison/Documents/src/others/sal/sal_env/lib/python2.7/site-packages/django/db/models/manager.py" in manager_method
  85.                 return getattr(self.get_queryset(), name)(*args, **kwargs)

File "/Users/clayton.burlison/Documents/src/others/sal/sal_env/lib/python2.7/site-packages/django/db/models/query.py" in get
  385.                 self.model._meta.object_name

Exception Type: DoesNotExist at /settings/plugins/machinedetail/enable/RemoteConnection/
Exception Value: MachineDetailPlugin matching query does not exist.
```