### PR TITLE
fix: Proper fix for when Crypt server is not set

### DIFF
--- a/server/plugins/cryptstatus/cryptstatus.py
+++ b/server/plugins/cryptstatus/cryptstatus.py
@@ -37,8 +37,8 @@ class CryptStatus(IPlugin):
         output = {}
         date_escrowed = None
         escrowed = None
-	if crypt_url:
-        request_url = crypt_url + '/verify/'+ serial + '/recovery_key/'
+        if crypt_url:
+            request_url = crypt_url + '/verify/' + serial + '/recovery_key/'
             try:
                 r = requests.get(request_url)
                 if r.status_code == requests.codes.ok:


### PR DESCRIPTION
whitespace/indentions in python matters.

This corrects the following bug that was introduced with #151

```bash
ERROR:yapsy:Unable to import plugin: /Users/clayton.burlison/Documents/src/others/sal/server/plugins/cryptstatus/cryptstatus
Traceback (most recent call last):
  File "/Users/clayton.burlison/Documents/src/others/sal/sal_env/lib/python2.7/site-packages/yapsy/PluginManager.py", line 488, in loadPlugins
    candidate_module = imp.load_module(plugin_module_name,plugin_file,candidate_filepath+".py",("py","r",imp.PY_SOURCE))
  File "/Users/clayton.burlison/Documents/src/others/sal/server/plugins/cryptstatus/cryptstatus.py", line 41
    request_url = crypt_url + '/verify/'+ serial + '/recovery_key/'
              ^
IndentationError: expected an indented block
```