### PR TITLE
fix: Update undeployed to work

### DIFF
--- a/search/management/commands/search_maintenance.py
+++ b/search/management/commands/search_maintenance.py
@@ -92,11 +92,11 @@ class Command(BaseCommand):
 
         # make sure this in an int:
         try:
-            int(settings.INACTIVE_UNDEPLOYED)
+            inactive_undeploy = int(settings.INACTIVE_UNDEPLOYED)
 
-            if settings.INACTIVE_UNDEPLOYED > 0:
+            if inactive_undeploy > 0:
                 now = django.utils.timezone.now()
-                inactive_days = now - timedelta(days=settings.INACTIVE_UNDEPLOYED)
-                machines_to_inactive = Machines.deployed_objects.all().filter(last_checkin__gte=inactive_days).update(deployed=False)
+                inactive_days = now - timedelta(days=inactive_undeploy)
+                machines_to_inactive = Machine.deployed_objects.all().filter(last_checkin__lte=inactive_days).update(deployed=False)
         except:
             pass


### PR DESCRIPTION
Should filter using less than or equal to find dates in the past not
greater than or equal which would be dates in the future.

This also corrects the machine call to use `Machine` (no 's')

---

I've tested this using the `INACTIVE_UNDEPLOYED = 90` setting with a machine that had the checkin date modified in the database. After running `python manage.py search_maintenance` the machine properly has it's object moved to the undeployed status.

With `DEPLOYED_ON_CHECKIN = True` enabled in the settings, I then had the machine checkin and Sal properly removed it from the undeployed status.

cc: @erikng 