### PR TITLE
Fix: illegal filter reference in InventoryItem

### DIFF
--- a/licenses/models.py
+++ b/licenses/models.py
@@ -20,7 +20,7 @@ class License(models.Model):
         # query inventory items to determine how many licenses have been used.
         items = InventoryItem.objects.all()
         if self.inventory_name:
-            items = items.filter(name__exact=self.inventory_name)
+            items = items.filter(application__name__exact=self.inventory_name)
         if self.inventory_version:
             if self.inventory_version.endswith('*'):
                 items = items.filter(


### PR DESCRIPTION
So I just tested the license seat tracking feature and got a 500 after I inserted the first license:

```python
   File "./licenses/models.py", line 23, in used
    items = items.filter(name__exact=self.inventory_name)
  File "/home/sal/.virtualenvs/sal/local/lib/python2.7/site-packages/django/db/models/query.py", line 794, in filter
    return self._filter_or_exclude(False, *args, **kwargs)
  File "/home/sal/.virtualenvs/sal/local/lib/python2.7/site-packages/django/db/models/query.py", line 812, in _filter_or_exclude
    clone.query.add_q(Q(*args, **kwargs))
  File "/home/sal/.virtualenvs/sal/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1227, in add_q
    clause, _ = self._add_q(q_object, self.used_aliases)
  File "/home/sal/.virtualenvs/sal/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1253, in _add_q
    allow_joins=allow_joins, split_subq=split_subq,
  File "/home/sal/.virtualenvs/sal/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1133, in build_filter
    lookups, parts, reffed_expression = self.solve_lookup_type(arg)
  File "/home/sal/.virtualenvs/sal/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1019, in solve_lookup_type
    _, field, _, lookup_parts = self.names_to_path(lookup_splitted, self.get_meta())
  File "/home/sal/.virtualenvs/sal/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1327, in names_to_path
    "Choices are: %s" % (name, ", ".join(available)))
FieldError: Cannot resolve keyword 'name' into field. Choices are: application, application_id, id, machine, machine_id, path, version
```

I guess this was a just a reference error to the application model.
