### PR TITLE
Fix: missing import for redirect in license views

### DIFF
--- a/licenses/views.py
+++ b/licenses/views.py
@@ -10,6 +10,7 @@ import plistlib
 import json
 from server.models import *
 from licenses.models import *
+from server import views as server_views
 
 @login_required
 def license_index(request):
@@ -18,7 +19,7 @@ def license_index(request):
     user = request.user
     user_level = user.userprofile.level
     if user_level != 'GA':
-        return redirect(server.views.index)
+        return redirect(server_views.index)
     c = {'request':request,
         'licenses': all_licenses,
          'user': request.user,
@@ -33,7 +34,7 @@ def new_license(request):
     user = request.user
     user_level = user.userprofile.level
     if user_level != 'GA':
-        return redirect(server.views.index)
+        return redirect(server_views.index)
     c.update(csrf(request))
     if request.method == 'POST':
         form = LicenseForm(request.POST)


### PR DESCRIPTION
Fixes:

```bash
[29/Nov/2017 18:38:45] ERROR [django.request:124] Internal Server Error: /licenses/
Traceback (most recent call last):
  File "/home/sal/.virtualenvs/sal/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 39, in inner
    response = get_response(request)
  File "/home/sal/.virtualenvs/sal/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/home/sal/.virtualenvs/sal/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/sal/.virtualenvs/sal/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/sal/.virtualenvs/sal/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 23, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "./licenses/views.py", line 21, in license_index
    return redirect(server.views.index)
NameError: global name 'server' is not defined
```