### PR TITLE
Update search_maint.sh for FreeBSD

### DIFF
--- a/setup/search_maint.sh
+++ b/setup/search_maint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd /usr/local/sal_install/sal
 export PYTHONPATH=/usr/local/sal_install/sal/sal:$PYTHONPATH


### PR DESCRIPTION
/usr/bin/env is in Linux, macOS and FreeBSD. This allows those of us running sal in FreeBSD to run the script without changing the documentation.