### PR TITLE
enable django autoescape for page-wrapper

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -152,8 +152,10 @@
         <div class="row">
             <div class="col-md-12">&nbsp;</div>
         </div>
+        {% autoescape on %}
             {% block content %}
             {% endblock %}
+        {% endautoescape %}
         <div class="row"><div class="col-md-12"><p class="pull-right">Sal version {{ SAL_VERSION }}</p></div></div>
         </div>
         <!-- /#page-wrapper -->


### PR DESCRIPTION
autoescape is a good way to prevent xss attacks.

currently doing something like
`curl "http://localhost:8000/%3E%3Cscript%3Ealert(document.domain)%3C/script%3E"` would inject the trailing url params into the template, and the system would attempt to run the script.

this will provide somewhat of a stop gap, while not perfect, would prevent most of these xss attacks from succeeding by turning the trailing params into garbage.

see https://docs.djangoproject.com/en/2.0/ref/templates/language/#automatic-html-escaping