### PR TITLE
adding unknown entries in encryption widget

### DIFF
--- a/server/plugins/encryption/encryption.py
+++ b/server/plugins/encryption/encryption.py
@@ -38,55 +38,55 @@ class Encryption(IPlugin):
                 t = loader.get_template('encryption/templates/id_laptops.html')
 
         try:
-            laptop_ok = machines.filter(pluginscriptsubmission__plugin='Encryption',
-                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name='Filevault',
-                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data='Enabled'
+            laptop_ok = machines.filter(pluginscriptsubmission__plugin='Encryption', # noqa: E501
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name='Filevault', # noqa: E501
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data='Enabled' # noqa: E501
                                        ).filter(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             laptop_ok = 0
 
         try:
-            desktop_ok = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
-                                         pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                         pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
+            desktop_ok = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                         pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                         pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
                                         ).exclude(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             desktop_ok = 0
 
         try:
-            laptop_alert = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
-                                           pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                           pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+            laptop_alert = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                           pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                           pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
                                           ).filter(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             laptop_alert = 0
 
         try:
-            desktop_alert = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
-                                            pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                            pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+            desktop_alert = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                            pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                            pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
                                            ).exclude(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             desktop_alert = 0
 
         try:
-            laptop_unk = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption',
-                                          pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                          pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
-                                         ).exclude(pluginscriptsubmission__plugin__exact='Encryption',
-                                                   pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                                   pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+            laptop_unk = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                          pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                          pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
+                                         ).exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                                   pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                                   pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
                                                   ).filter(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             laptop_unk = 0
 
         try:
-            desktop_unk = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption',
-                                           pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                           pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
-                                          ).exclude(pluginscriptsubmission__plugin__exact='Encryption',
-                                                    pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                                    pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+            desktop_unk = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                           pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                           pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
+                                          ).exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                                    pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                                    pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
                                                    ).exclude(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             desktop_unk = 0
@@ -109,50 +109,50 @@ class Encryption(IPlugin):
 
     def filter_machines(self, machines, data):
         if data == 'laptopok':
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
                                       ).filter(machine_model__contains='Book')  # noqa: E501
             title = 'Laptops with encryption enabled'
 
         elif data == 'desktopok':
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
                                       ).exclude(machine_model__contains='Book')  # noqa: E501
             title = 'Desktops with encryption enabled'
 
         elif data == 'laptopalert':
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
                                       ).filter(machine_model__contains='Book')  # noqa: E501
             title = 'Laptops without encryption enabled'
 
         elif data == 'desktopalert':
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
                                       ).exclude(machine_model__contains='Book')  # noqa: E501
             title = 'Desktops without encryption enabled'
 
         elif data == 'laptopunk':
-            machines = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption',
-                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
-                                       ).exclude(pluginscriptsubmission__plugin__exact='Encryption',
-                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+            machines = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
+                                       ).exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
                                                 ).filter(machine_model__contains='Book')  # noqa: E501
             title = 'Laptops with Unknown encryption state'
 
         elif data == 'desktopunk':
-            machines = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption',
-                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
-                                       ).exclude(pluginscriptsubmission__plugin__exact='Encryption',
-                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
-                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+            machines = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
+                                       ).exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
+                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
+                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
                                                 ).exclude(machine_model__contains='Book')  # noqa: E501
             title = 'Desktops with Unknown encryption state'
 

--- a/server/plugins/encryption/encryption.py
+++ b/server/plugins/encryption/encryption.py
@@ -38,55 +38,55 @@ class Encryption(IPlugin):
                 t = loader.get_template('encryption/templates/id_laptops.html')
 
         try:
-            laptop_ok = machines.filter(pluginscriptsubmission__plugin='Encryption', # noqa: E501
-                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name='Filevault', # noqa: E501
-                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data='Enabled' # noqa: E501
+            laptop_ok = machines.filter(pluginscriptsubmission__plugin='Encryption',  # noqa: E501
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name='Filevault',  # noqa: E501
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data='Enabled'  # noqa: E501
                                        ).filter(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             laptop_ok = 0
 
         try:
-            desktop_ok = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                         pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                         pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
+            desktop_ok = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                         pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                         pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'  # noqa: E501
                                         ).exclude(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             desktop_ok = 0
 
         try:
-            laptop_alert = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                           pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                           pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
+            laptop_alert = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                           pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                           pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'  # noqa: E501
                                           ).filter(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             laptop_alert = 0
 
         try:
-            desktop_alert = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                            pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                            pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
+            desktop_alert = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                            pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                            pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'  # noqa: E501
                                            ).exclude(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             desktop_alert = 0
 
         try:
-            laptop_unk = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                          pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                          pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
-                                         ).exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                                   pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                                   pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
+            laptop_unk = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                          pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                          pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'  # noqa: E501
+                                         ).exclude(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                                   pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                                   pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'  # noqa: E501
                                                   ).filter(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             laptop_unk = 0
 
         try:
-            desktop_unk = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                           pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                           pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
-                                          ).exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                                    pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                                    pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
+            desktop_unk = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                           pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                           pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'  # noqa: E501
+                                          ).exclude(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                                    pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                                    pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'  # noqa: E501
                                                    ).exclude(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             desktop_unk = 0
@@ -109,50 +109,50 @@ class Encryption(IPlugin):
 
     def filter_machines(self, machines, data):
         if data == 'laptopok':
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'  # noqa: E501
                                       ).filter(machine_model__contains='Book')  # noqa: E501
             title = 'Laptops with encryption enabled'
 
         elif data == 'desktopok':
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'  # noqa: E501
                                       ).exclude(machine_model__contains='Book')  # noqa: E501
             title = 'Desktops with encryption enabled'
 
         elif data == 'laptopalert':
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'  # noqa: E501
                                       ).filter(machine_model__contains='Book')  # noqa: E501
             title = 'Laptops without encryption enabled'
 
         elif data == 'desktopalert':
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'  # noqa: E501
                                       ).exclude(machine_model__contains='Book')  # noqa: E501
             title = 'Desktops without encryption enabled'
 
         elif data == 'laptopunk':
-            machines = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
-                                       ).exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
+            machines = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'  # noqa: E501
+                                       ).exclude(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'  # noqa: E501
                                                 ).filter(machine_model__contains='Book')  # noqa: E501
             title = 'Laptops with Unknown encryption state'
 
         elif data == 'desktopunk':
-            machines = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled' # noqa: E501
-                                       ).exclude(pluginscriptsubmission__plugin__exact='Encryption', # noqa: E501
-                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', # noqa: E501
-                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled' # noqa: E501
+            machines = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'  # noqa: E501
+                                       ).exclude(pluginscriptsubmission__plugin__exact='Encryption',  # noqa: E501
+                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',  # noqa: E501
+                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'  # noqa: E501
                                                 ).exclude(machine_model__contains='Book')  # noqa: E501
             title = 'Desktops with Unknown encryption state'
 

--- a/server/plugins/encryption/encryption.py
+++ b/server/plugins/encryption/encryption.py
@@ -38,33 +38,69 @@ class Encryption(IPlugin):
                 t = loader.get_template('encryption/templates/id_laptops.html')
 
         try:
-            laptop_ok = machines.filter(pluginscriptsubmission__plugin='Encryption', pluginscriptsubmission__pluginscriptrow__pluginscript_name='Filevault', pluginscriptsubmission__pluginscriptrow__pluginscript_data='Enabled').filter(machine_model__contains='Book').count()  # noqa: E501
+            laptop_ok = machines.filter(pluginscriptsubmission__plugin='Encryption',
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name='Filevault',
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data='Enabled'
+                                       ).filter(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             laptop_ok = 0
 
         try:
-            desktop_ok = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled').exclude(machine_model__contains='Book').count()  # noqa: E501
+            desktop_ok = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
+                                         pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                         pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
+                                        ).exclude(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             desktop_ok = 0
 
         try:
-            laptop_alert = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled').filter(machine_model__contains='Book').count()  # noqa: E501
+            laptop_alert = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
+                                           pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                           pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+                                          ).filter(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             laptop_alert = 0
 
         try:
-            desktop_alert = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled').exclude(machine_model__contains='Book').count()  # noqa: E501
+            desktop_alert = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
+                                            pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                            pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+                                           ).exclude(machine_model__contains='Book').count()  # noqa: E501
         except Exception:
             desktop_alert = 0
+
+        try:
+            laptop_unk = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption',
+                                          pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                          pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
+                                         ).exclude(pluginscriptsubmission__plugin__exact='Encryption',
+                                                   pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                                   pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+                                                  ).filter(machine_model__contains='Book').count()  # noqa: E501
+        except Exception:
+            laptop_unk = 0
+
+        try:
+            desktop_unk = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption',
+                                           pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                           pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
+                                          ).exclude(pluginscriptsubmission__plugin__exact='Encryption',
+                                                    pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                                    pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+                                                   ).exclude(machine_model__contains='Book').count()  # noqa: E501
+        except Exception:
+            desktop_unk = 0
 
         c = Context({
             'title': 'Encryption',
             'laptop_label': 'Laptops',
             'laptop_ok_count': laptop_ok,
             'laptop_alert_count': laptop_alert,
+            'laptop_unknown_count': laptop_unk,
+            'desktop_label': 'Desktops',
             'desktop_ok_count': desktop_ok,
             'desktop_alert_count': desktop_alert,
-            'desktop_label': 'Desktops',
+            'desktop_unknown_count': desktop_unk,
             'plugin': 'Encryption',
             'theid': theid,
             'page': page
@@ -73,20 +109,52 @@ class Encryption(IPlugin):
 
     def filter_machines(self, machines, data):
         if data == 'laptopok':
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled').filter(machine_model__contains='Book')  # noqa: E501
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
+                                      ).filter(machine_model__contains='Book')  # noqa: E501
             title = 'Laptops with encryption enabled'
 
         elif data == 'desktopok':
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled').exclude(machine_model__contains='Book')  # noqa: E501
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
+                                      ).exclude(machine_model__contains='Book')  # noqa: E501
             title = 'Desktops with encryption enabled'
 
         elif data == 'laptopalert':
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled').filter(machine_model__contains='Book')  # noqa: E501
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+                                      ).filter(machine_model__contains='Book')  # noqa: E501
             title = 'Laptops without encryption enabled'
 
         elif data == 'desktopalert':
-            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption', pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault', pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled').exclude(machine_model__contains='Book')  # noqa: E501
+            machines = machines.filter(pluginscriptsubmission__plugin__exact='Encryption',
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                       pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+                                      ).exclude(machine_model__contains='Book')  # noqa: E501
             title = 'Desktops without encryption enabled'
+
+        elif data == 'laptopunk':
+            machines = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption',
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
+                                       ).exclude(pluginscriptsubmission__plugin__exact='Encryption',
+                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+                                                ).filter(machine_model__contains='Book')  # noqa: E501
+            title = 'Laptops with Unknown encryption state'
+
+        elif data == 'desktopunk':
+            machines = machines.exclude(pluginscriptsubmission__plugin__exact='Encryption',
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                        pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Enabled'
+                                       ).exclude(pluginscriptsubmission__plugin__exact='Encryption',
+                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_name__exact='Filevault',
+                                                 pluginscriptsubmission__pluginscriptrow__pluginscript_data__exact='Disabled'
+                                                ).exclude(machine_model__contains='Book')  # noqa: E501
+            title = 'Desktops with Unknown encryption state'
 
         else:
             machines = None

--- a/server/plugins/encryption/templates/front_desktops.html
+++ b/server/plugins/encryption/templates/front_desktops.html
@@ -25,14 +25,18 @@
             <i class="fa fa-desktop fa-2x"></i>
           </a>
 
+          {% if laptop_unknown_count > 0 %}
           <a href="{% url 'machine_list_front' plugin 'laptopunk' %}" title="{{ laptop_label }}" class="btn btn-danger">
             <span class="bigger">{{ laptop_unknown_count }}</span><br />
             <i class="fa fa-laptop fa-2x"></i>
           </a>
+          {% endif %}
 
+          {% if desktop_unknown_count > 0 %}
           <a href="{% url 'machine_list_front' plugin 'desktopunk' %}" title="{{ desktop_label }}" class="btn btn-danger">
             <span class="bigger">{{ desktop_unknown_count }}</span><br />
             <i class="fa fa-desktop fa-2x"></i>
           </a>
+          {% endif %}
         </div>
       </div>

--- a/server/plugins/encryption/templates/front_desktops.html
+++ b/server/plugins/encryption/templates/front_desktops.html
@@ -5,24 +5,34 @@
         </div>
         <!-- /.panel-heading -->
         <div class="panel-body">
-<a href="{% url 'machine_list_front' plugin 'laptopok' %}" title="{{ laptop_label }}" class="text-center btn btn-success">
-      <span class="bigger">{{ laptop_ok_count }}</span><br />
-      <i class="fa fa-laptop fa-2x"></i>
+          <a href="{% url 'machine_list_front' plugin 'laptopok' %}" title="{{ laptop_label }}" class="text-center btn btn-success">
+            <span class="bigger">{{ laptop_ok_count }}</span><br />
+            <i class="fa fa-laptop fa-2x"></i>
           </a>
 
           <a href="{% url 'machine_list_front' plugin 'desktopok' %}" title="{{ desktop_label }}" class="btn btn-success">
-      <span class="bigger">{{ desktop_ok_count }}</span><br />
-      <i class="fa fa-desktop fa-2x"></i>
+            <span class="bigger">{{ desktop_ok_count }}</span><br />
+            <i class="fa fa-desktop fa-2x"></i>
           </a>
 
           <a href="{% url 'machine_list_front' plugin 'laptopalert' %}" title="{{ laptop_label }}" class="btn btn-danger">
-      <span class="bigger">{{ laptop_alert_count }}</span><br />
-      <i class="fa fa-laptop fa-2x"></i>
+            <span class="bigger">{{ laptop_alert_count }}</span><br />
+            <i class="fa fa-laptop fa-2x"></i>
           </a>
 
           <a href="{% url 'machine_list_front' plugin 'desktopalert' %}" title="{{ desktop_label }}" class="btn btn-danger">
-      <span class="bigger">{{ desktop_alert_count }}</span><br />
-      <i class="fa fa-desktop fa-2x"></i>
+            <span class="bigger">{{ desktop_alert_count }}</span><br />
+            <i class="fa fa-desktop fa-2x"></i>
+          </a>
+
+          <a href="{% url 'machine_list_front' plugin 'laptopunk' %}" title="{{ laptop_label }}" class="btn btn-danger">
+            <span class="bigger">{{ laptop_unknown_count }}</span><br />
+            <i class="fa fa-laptop fa-2x"></i>
+          </a>
+
+          <a href="{% url 'machine_list_front' plugin 'desktopunk' %}" title="{{ desktop_label }}" class="btn btn-danger">
+            <span class="bigger">{{ desktop_unknown_count }}</span><br />
+            <i class="fa fa-desktop fa-2x"></i>
           </a>
         </div>
       </div>

--- a/server/plugins/encryption/templates/front_laptops.html
+++ b/server/plugins/encryption/templates/front_laptops.html
@@ -14,5 +14,10 @@
             <span class="bigger">{{ laptop_alert_count }}</span><br />
             <i class="fa fa-laptop fa-3x"></i>
           </a>
+
+          <a href="{% url 'machine_list_front' plugin 'laptopunk' %}" title="{{ laptop_label }}" class="btn btn-danger">
+            <span class="bigger">{{ laptop_unknown_count }}</span><br />
+            <i class="fa fa-laptop fa-3x"></i>
+          </a>
         </div>
       </div>

--- a/server/plugins/encryption/templates/front_laptops.html
+++ b/server/plugins/encryption/templates/front_laptops.html
@@ -15,9 +15,11 @@
             <i class="fa fa-laptop fa-3x"></i>
           </a>
 
+          {% if laptop_unknown_count > 0 %}
           <a href="{% url 'machine_list_front' plugin 'laptopunk' %}" title="{{ laptop_label }}" class="btn btn-danger">
             <span class="bigger">{{ laptop_unknown_count }}</span><br />
             <i class="fa fa-laptop fa-3x"></i>
           </a>
+          {% endif %}
         </div>
       </div>

--- a/server/plugins/encryption/templates/id_desktops.html
+++ b/server/plugins/encryption/templates/id_desktops.html
@@ -5,24 +5,34 @@
         </div>
         <!-- /.panel-heading -->
         <div class="panel-body">
-<a href="{% url 'machine_list_id' plugin 'laptopok' page theid %}" title="{{ laptop_label }}" class="btn btn-success">
-      <span class="bigger">{{ laptop_ok_count }}</span><br />
-      <i class="fa fa-laptop fa-2x"></i>
+          <a href="{% url 'machine_list_id' plugin 'laptopok' page theid %}" title="{{ laptop_label }}" class="btn btn-success">
+            <span class="bigger">{{ laptop_ok_count }}</span><br />
+            <i class="fa fa-laptop fa-2x"></i>
           </a>
 
           <a href="{% url 'machine_list_id' plugin 'desktopok' page theid %}" title="{{ desktop_label }}" class="btn btn-success">
-      <span class="bigger">{{ desktop_ok_count }}</span><br />
-      <i class="fa fa-desktop fa-2x"></i>
+            <span class="bigger">{{ desktop_ok_count }}</span><br />
+            <i class="fa fa-desktop fa-2x"></i>
           </a>
 
           <a href="{% url 'machine_list_id' plugin 'laptopalert' page theid %}" title="{{ laptop_label }}" class="btn btn-danger">
-      <span class="bigger">{{ laptop_alert_count }}</span><br />
-      <i class="fa fa-laptop fa-2x"></i>
+            <span class="bigger">{{ laptop_alert_count }}</span><br />
+            <i class="fa fa-laptop fa-2x"></i>
           </a>
 
           <a href="{% url 'machine_list_id' plugin 'desktopalert' page theid %}" title="{{ desktop_label }}" class="btn btn-danger">
-      <span class="bigger">{{ desktop_alert_count }}</span><br />
-      <i class="fa fa-desktop fa-2x"></i>
+            <span class="bigger">{{ desktop_alert_count }}</span><br />
+            <i class="fa fa-desktop fa-2x"></i>
+          </a>
+
+          <a href="{% url 'machine_list_id' plugin 'laptopunk' page theid %}" title="{{ laptop_label }}" class="btn btn-danger">
+            <span class="bigger">{{ laptop_unknown_count }}</span><br />
+            <i class="fa fa-laptop fa-2x"></i>
+          </a>
+
+          <a href="{% url 'machine_list_id' plugin 'desktopunk' page theid %}" title="{{ desktop_label }}" class="btn btn-danger">
+            <span class="bigger">{{ desktop_unknown_count }}</span><br />
+            <i class="fa fa-desktop fa-2x"></i>
           </a>
         </div>
       </div>

--- a/server/plugins/encryption/templates/id_desktops.html
+++ b/server/plugins/encryption/templates/id_desktops.html
@@ -25,14 +25,18 @@
             <i class="fa fa-desktop fa-2x"></i>
           </a>
 
+          {% if laptop_unknown_count > 0 %}
           <a href="{% url 'machine_list_id' plugin 'laptopunk' page theid %}" title="{{ laptop_label }}" class="btn btn-danger">
             <span class="bigger">{{ laptop_unknown_count }}</span><br />
             <i class="fa fa-laptop fa-2x"></i>
           </a>
+          {% endif %}
 
+          {% if desktop_unknown_count > 0 %}
           <a href="{% url 'machine_list_id' plugin 'desktopunk' page theid %}" title="{{ desktop_label }}" class="btn btn-danger">
             <span class="bigger">{{ desktop_unknown_count }}</span><br />
             <i class="fa fa-desktop fa-2x"></i>
           </a>
+          {% endif %}
         </div>
       </div>

--- a/server/plugins/encryption/templates/id_laptops.html
+++ b/server/plugins/encryption/templates/id_laptops.html
@@ -15,9 +15,11 @@
             <i class="fa fa-laptop fa-3x"></i>
           </a>
 
+          {% if laptop_unknown_count > 0 %}
           <a href="{% url 'machine_list_id' plugin 'laptopunk' page theid %}" title="{{ laptop_label }}" class="btn btn-danger">
             <span class="bigger">{{ laptop_unknown_count }}</span><br />
             <i class="fa fa-laptop fa-3x"></i>
           </a>
+          {% endif %}
         </div>
       </div>

--- a/server/plugins/encryption/templates/id_laptops.html
+++ b/server/plugins/encryption/templates/id_laptops.html
@@ -14,5 +14,10 @@
             <span class="bigger">{{ laptop_alert_count }}</span><br />
             <i class="fa fa-laptop fa-3x"></i>
           </a>
+
+          <a href="{% url 'machine_list_id' plugin 'laptopunk' page theid %}" title="{{ laptop_label }}" class="btn btn-danger">
+            <span class="bigger">{{ laptop_unknown_count }}</span><br />
+            <i class="fa fa-laptop fa-3x"></i>
+          </a>
         </div>
       </div>


### PR DESCRIPTION
Added a second 'red' panel in the encryption widget to account for systems where the encryption status didn't report properly for some reasons. I am not sure if that should be changed to be yellow, and the order adjusted to be green-yellow-red. Let me know and i'll adjust the templates.