### PR TITLE
fix: Add page_length support for facter/condition

### DIFF
--- a/server/templates/server/machine_detail_table.html
+++ b/server/templates/server/machine_detail_table.html
@@ -6,6 +6,7 @@
 <script type="text/javascript" charset="utf-8">
     $(document).ready(function() {
         $('.groupList').DataTable({
+            "pageLength": {{ page_length }},
             "lengthMenu": [[20, 50, -1], [20, 50, "All"]],
             'columnDefs': [{
                 'orderable': false,

--- a/server/views.py
+++ b/server/views.py
@@ -433,13 +433,15 @@ def machine_detail_facter(request, machine_id, **kwargs):
     key_header = 'Fact'
     value_header = 'Data'
     title = 'Facter data for %s' % machine.hostname
+    page_length = utils.get_setting('datatable_page_length')
     c = {
         'user': request.user,
         'machine': machine,
         'table_data': table_data,
         'title': title,
         'key_header': key_header,
-        'value_header': value_header
+        'value_header': value_header,
+        'page_length': page_length
     }
     return render(request, 'server/machine_detail_table.html', c)
 
@@ -466,13 +468,15 @@ def machine_detail_conditions(request, machine_id, **kwargs):
     key_header = 'Condition'
     value_header = 'Data'
     title = 'Munki conditions data for %s' % machine.hostname
+    page_length = utils.get_setting('datatable_page_length')
     c = {
         'user': request.user,
         'machine': machine,
         'table_data': table_data,
         'title': title,
         'key_header': key_header,
-        'value_header': value_header
+        'value_header': value_header,
+        'page_length': page_length
     }
     return render(request, 'server/machine_detail_table.html', c)
 


### PR DESCRIPTION
This will allow the machine details datatable to respect the
'datatable_page_length' key.