### PR TITLE
update for postgresql10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -r setup/requirements.txt
 gunicorn==19.6.0
-psycopg2==2.6.2
+psycopg2==2.7.1
 setproctitle==1.1.10


### PR DESCRIPTION
postgresql 10 and older version of psycopg don't work together. This version should work.

This should address #218 