### PR TITLE
Filter undeployed from app inventory

### DIFF
--- a/inventory/views.py
+++ b/inventory/views.py
@@ -127,6 +127,13 @@ class GroupMixin(object):
                 kwargs = {filter_path: self.group_instance}
                 queryset = queryset.filter(**kwargs)
 
+        # Remove undeployed machines from the results.
+        # This is a little wild, but it's either this or use an eval to
+        # construct the keyword argument name to filter.
+        deployed_filter = '{}{}deployed'.format(
+            self.access_filter[queryset.model][Machine], '' if queryset.model is Machine else '__')
+        queryset = queryset.filter(**{deployed_filter: True})
+
         return queryset
 
 

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -128,6 +128,12 @@ class GroupMixin(object):
                 queryset = queryset.filter(**kwargs)
 
         # Remove undeployed machines from the results.
+        # It's important that we are filtering for deployed machines
+        # here rather than excluding undeployed machines-you get
+        # different results (exclude undeployed will exclude
+        # Applications from list views that have ANY undeployed
+        # machines.
+
         # This is a little wild, but it's either this or use an eval to
         # construct the keyword argument name to filter.
         deployed_filter = '{}{}deployed'.format(

--- a/search/management/commands/search_maintenance.py
+++ b/search/management/commands/search_maintenance.py
@@ -150,5 +150,10 @@ class Command(BaseCommand):
 
         if server.utils.is_postgres() and items_to_be_inserted != []:
             SearchCache.objects.bulk_create(items_to_be_inserted)
+
+
+        # Clean up orhpaned Application objects.
+        Application.objects.filter(inventoryitem=None).delete()
+
         sleep_time = options['sleep_time']
         sleep(sleep_time)

--- a/search/management/commands/search_maintenance.py
+++ b/search/management/commands/search_maintenance.py
@@ -151,7 +151,6 @@ class Command(BaseCommand):
         if server.utils.is_postgres() and items_to_be_inserted != []:
             SearchCache.objects.bulk_create(items_to_be_inserted)
 
-
         # Clean up orhpaned Application objects.
         Application.objects.filter(inventoryitem=None).delete()
 


### PR DESCRIPTION
This PR updates the inventory app to exclude InventoryItems (and thus Applications on the Application list view) that are from undeployed computers.

It also cleans up the Application table by using the search_maintenance command to delete Applications which have zero InventoryItems.