### PR TITLE
Add `__repr__` method to `OldPluginWrapper` so proper name is displayed.

### DIFF
--- a/sal/plugin.py
+++ b/sal/plugin.py
@@ -371,6 +371,9 @@ class OldPluginAdapter(BasePlugin):
     def __init__(self, plugin):
         self.plugin = plugin
 
+    def __repr__(self):
+        return self.plugin.__class__.__name__
+
     @property
     def enabled(self):
         plugin_type = self.get_plugin_type()


### PR DESCRIPTION
This is only really an issue in the plugin settings views.