### PR TITLE
Construct full path to plugin templates to help load 3rd party plugins.

### DIFF
--- a/sal/plugin.py
+++ b/sal/plugin.py
@@ -164,8 +164,12 @@ class BasePlugin(IPlugin):
         Returns:
             Django template for this plugin.
         """
-        template = self.template if self.template else "{0}/templates/{0}.html".format(
-            self.__class__.__name__.lower())
+        if self.template:
+            template = self.template
+        else:
+            # Construct path to templates from plugin's full path.
+            template = "{0}/templates/{1}.html".format(
+                self.path[:self.path.rfind('/')], self.__class__.__name__.lower())
         return loader.get_template(template)
 
     def get_supported_os_families(self, **kwargs):


### PR DESCRIPTION
The configured template search paths can't recurse into subdirectories,
so instead this updates the plugin base class to auto-construct a full
path to the template by taking the plugin module's path, chopping the
end off, and catting on `templates/<name>.html`.