### PR TITLE
Fix issue with no results from Apple pending updates plugin machine list

### DIFF
--- a/server/plugins/pendingappleupdates/pendingappleupdates.py
+++ b/server/plugins/pendingappleupdates/pendingappleupdates.py
@@ -31,8 +31,8 @@ class PendingAppleUpdates(sal.plugin.Widget):
         except ValueError:
             return None, None
 
-        machines = machines.filter(pending_updates__update=update_name,
-                                   pending_updates__update_version=update_version)
+        machines = machines.filter(pending_apple_updates__update=update_name,
+                                   pending_apple_updates__update_version=update_version)
 
         # get the display name of the update
         try:


### PR DESCRIPTION
This should fix it. I haven't tested it except by manually doing the query in the django shell.