### PR TITLE
Make get_plugin_by_name do what it says it does.

### DIFF
--- a/sal/plugin.py
+++ b/sal/plugin.py
@@ -482,8 +482,10 @@ class PluginManager(object):
             Widget, Report, or DetailPlugin instance, or None if no
             plugin was found with this name.
         """
-        plugin = self.wrap_old_plugins([self.manager.getPluginByName(name)])[0]
-        return plugin
+        plugin = self.manager.getPluginByName(name)
+        if plugin:
+            plugins = self.wrap_old_plugins([plugin])
+            return plugins[0] if plugins else None
 
     def get_all_plugins(self):
         """Return a list of all plugins found in configured directories.


### PR DESCRIPTION
I.e. don't blow up when trying to wrap old plugins if you haven't found
any plugins with that name.