### PR TITLE
Fix excessive version checking

### DIFF
--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -752,11 +752,7 @@ def checkin(request):
 
     if utils.get_setting('send_data') in (None, True):
         # If setting is None, it hasn't been configured yet; assume True
-        current_version = utils.send_report()
-    else:
-        current_version = utils.get_current_release_version_number()
-    if current_version:
-        utils.set_setting('current_version', current_version)
+        utils.send_report()
 
     return HttpResponse("Sal report submmitted for %s"
                         % data.get('name'))

--- a/server/utils.py
+++ b/server/utils.py
@@ -108,7 +108,7 @@ def send_report():
 
     current_time = time.time()
 
-    if last_sent < (current_time - TWENTY_FOUR_HOURS):
+    if last_sent > (current_time - TWENTY_FOUR_HOURS):
         output = {}
 
         # get total number of machines

--- a/server/utils.py
+++ b/server/utils.py
@@ -76,16 +76,29 @@ def get_server_version():
 def get_current_release_version_number():
     """Get the currently available Sal version.
 
+    Only checks once per 24 hours.
+
     Returns:
         (str) Version number if it could be retrieved, otherwise None.
     """
+    last_version_check = get_setting('last_version_check_date', 0)
+    current_time = time.time()
     current_version = None
-    try:
-        response = requests.get('https://version.salopensource.com')
-        if response.status_code == 200:
-            current_version = response.text
-    except requests.exceptions.RequestException:
-        pass
+
+    if last_version_check < (current_time - TWENTY_FOUR_HOURS):
+        try:
+            response = requests.get('https://version.salopensource.com')
+            if response.status_code == 200:
+                current_version = response.text
+        except requests.exceptions.RequestException:
+            pass
+
+        if current_version:
+            set_setting('last_version_check_date', int(current_time))
+            set_setting('current_version', current_version)
+    else:
+        current_version = get_setting('current_version')
+
     return current_version
 
 
@@ -97,18 +110,12 @@ def get_install_type():
 
 
 def send_report():
-    """Send report data if last report was sent over 24 hours ago.
-
-    Returns:
-        (str) current Sal version number or None if there was a problem
-        retrieving it. This will return regardless of whether the report
-        needed to be sent.
-    """
+    """Send report data if last report was sent over 24 hours ago."""
     last_sent = get_setting('last_sent_data', 0)
 
     current_time = time.time()
 
-    if last_sent > (current_time - TWENTY_FOUR_HOURS):
+    if last_sent < (current_time - TWENTY_FOUR_HOURS):
         output = {}
 
         # get total number of machines
@@ -137,8 +144,6 @@ def send_report():
             return response.text
         else:
             return None
-    else:
-        return get_current_release_version_number()
 
 
 def check_version():
@@ -157,9 +162,7 @@ def check_version():
     result = {'new_version_available': False, 'new_version': False, 'server_version': False}
 
     server_version = get_server_version()
-    # Grab this from the database so we're not making requests all
-    # the time.
-    current_release_version = get_setting('current_version', '0')
+    current_release_version = get_current_release_version_number() or '0.0.0'
 
     # Only do something if running version is out of date.
     if LooseVersion(current_release_version) > LooseVersion(server_version):


### PR DESCRIPTION
This should be ready to go as-is; however, wondering about version checking strategy.

This PR currently hides the version check procedure from clients and will only do it once every 24 hours.

Alternately, we could move the new release check to the "search maintenance" script.

Or, as described in the commit log, we could just have it check every time a GA user visits the main page, since it will now not be done with every machine checkin like before.