### PR TITLE
Configure graceful_timeout to actually do something

### DIFF
--- a/docker/gunicorn_config.py
+++ b/docker/gunicorn_config.py
@@ -3,14 +3,15 @@ from os import getenv
 bind = '127.0.0.1:8001'
 
 workers = multiprocessing.cpu_count() * 3
-# graceful_timeout = 600
-# timeout = 60
+graceful_timeout = 15
+timeout = 30
 threads = multiprocessing.cpu_count() * 3
-# max_requests = 300
+
 pidfile = '/var/run/gunicorn.pid'
-# max_requests_jitter = 50
+
 errorlog = '/var/log/gunicorn/gunicorn-error.log'
 loglevel = 'critical'
+
 # Read the DEBUG setting from env var
 try:
     if getenv('DOCKER_SAL_DEBUG').lower() == 'true':


### PR DESCRIPTION
This will give threads 15 seconds to restart before gunicorn gives them the 🖕 