### PR TITLE
fix: Allow a user to be given superuser access

### DIFF
--- a/server/admin.py
+++ b/server/admin.py
@@ -230,7 +230,7 @@ class CustomUserAdmin(admin.ModelAdmin):
     search_fields = ('username', )
     fields = (
         ('username', 'first_name', 'last_name', 'email'),
-        ('is_staff', 'is_active'),
+        ('is_staff', 'is_active', 'is_superuser'),
         ('last_login', 'date_joined'),
     )
 


### PR DESCRIPTION
~This does resolve the issue regarding /admin access but I'm not sure if the right way. Django admin really wants `is_superuser`, from what I can see, and IMO if we are granting GA access to someone they might as well be able to go muck around in /admin.~

Fix #248