### PR TITLE
fix the memory_kb conversion to computer the right value

### DIFF
--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -405,9 +405,9 @@ def checkin(request):
         machine.cpu_speed = hwinfo.get(MACHINE_KEYS['cpu_speed'][key_style])
         machine.memory = hwinfo.get(MACHINE_KEYS['memory'][key_style])
         try:
-            machine.memory_kb = int(machine.memory[:-3]) ** MEMORY_EXPONENTS[machine.memory[-2:]]
+            machine.memory_kb = int(machine.memory[:-3]) * 1024 ** MEMORY_EXPONENTS[machine.memory[-2:]]
         except ValueError:
-            machine.memory_kb = int(float(machine.memory[:-3])) ** \
+            machine.memory_kb = int(float(machine.memory[:-3])) * 1024 ** \
                 MEMORY_EXPONENTS[machine.memory[-2:]]
 
     # if not machine.machine_model_friendly:


### PR DESCRIPTION
The memory widget on the dashboard is reporting erroneous data. 
The plugin appears to do the right thing: comparing `memory_kb` to 4 * GB where GB is defined as `1024*1024`

Looking further at the database, a machine with 16GB of ram appears to have a value of 256 (16**2) in memory_kb (you can inspect your own data in the admin site, looking at any machine). a machine with 64GB similarly would have a value of 4096 (64**2)

The value stored in memory_kb is computed here (and the next couple lines). 
https://github.com/salopensource/sal/blob/94fbce904d928b65e092ca23d0541d54bd94c930/server/non_ui_views.py#L408

If we have 16GB of memory, we should get the value 16777216 (16 * 1GB) for `memory_kb`.

The bug was introduced in https://github.com/salopensource/sal/pull/240/commits/55a0e16f88e4a25851b893e9b7387b28f36339be where the changed the computation from `<size> * 1024 ** exponent` to `<size> ** exponent.`. This corrects the computation.

I'm hoping @sheagcraig can review and approve the change...
