### PR TITLE
default value for compressed_profiles

### DIFF
--- a/profiles/views.py
+++ b/profiles/views.py
@@ -38,6 +38,7 @@ def submit_profiles(request):
             return HttpResponseNotFound('Serial Number not found')
 
         compression_type = 'base64bz2'
+        compressed_profile = None
         if 'base64bz2profiles' in submission:
             compressed_profiles = submission.get('base64bz2profiles')
         elif 'base64profiles' in submission:

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -38,7 +38,7 @@ def submit_profiles(request):
             return HttpResponseNotFound('Serial Number not found')
 
         compression_type = 'base64bz2'
-        compressed_profile = None
+        compressed_profiles = None
         if 'base64bz2profiles' in submission:
             compressed_profiles = submission.get('base64bz2profiles')
         elif 'base64profiles' in submission:


### PR DESCRIPTION
https://github.com/salopensource/sal/blob/1f1485615e9bb533cb70b7c7c5cef013e3bc248d/profiles/views.py#L40-L46

There appears to be scenario where the `compressed_profiles` variable is reported being used before assignment:
```
  File "/usr/local/sal_install/sal/profiles/views.py", line 46, in submit_profiles
    if compressed_profiles:
UnboundLocalError: local variable 'compressed_profiles' referenced before assignment
```

This simply sets a default to `None`, and would cause the code to fall down to the 'no profiles submitted'