### PR TITLE
fix: fact_recorded must be set on HistoricalFacts

### DIFF
--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -565,7 +565,7 @@ def process_facts(machine, report_data, datelimit):
 
         if fact_name in HISTORICAL_FACTS:
             historical_facts_to_be_created.append(
-                HistoricalFact(machine=machine, fact_data=fact_data, fact_name=fact_name))
+                HistoricalFact(machine=machine, fact_data=fact_data, fact_name=fact_name, fact_recorded=django.utils.timezone.now()))
 
     if facts_to_be_created:
         if IS_POSTGRES:

--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -565,7 +565,11 @@ def process_facts(machine, report_data, datelimit):
 
         if fact_name in HISTORICAL_FACTS:
             historical_facts_to_be_created.append(
-                HistoricalFact(machine=machine, fact_data=fact_data, fact_name=fact_name, fact_recorded=django.utils.timezone.now()))
+                HistoricalFact(
+                    machine=machine,
+                    fact_data=fact_data,
+                    fact_name=fact_name,
+                    fact_recorded=django.utils.timezone.now()))
 
     if facts_to_be_created:
         if IS_POSTGRES:


### PR DESCRIPTION
What's on the tin. One line change - when HistoricalFacts are recorded during checkin process, a fact_recorded datetime field must set. Uses django's util for getting the timezone right. Example exception:

```
IntegrityError: null value in column "fact_recorded" violates not-null constraint
DETAIL:  Failing row contains (944500, memoryfree_mb, 153.63671875, null, 895).
```