### PR TITLE
Fix issue 274

### DIFF
--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -47,11 +47,6 @@ MACHINE_KEYS = {
     'cpu_type': {'old': 'CPUType', 'new': 'cpu_type'},
     'cpu_speed': {'old': 'CurrentProcessorSpeed', 'new': 'current_processor_speed'},
     'memory': {'old': 'PhysicalMemory', 'new': 'physical_memory'}}
-UPDATE_META = {
-    'AppleUpdates': {'update_type': 'apple'},
-    'ManagedInstalls': {'update_type': 'third_party'},
-    'InstallResults': {'status': 'install'},
-    'RemovalResults': {'status': 'removal'}}
 MEMORY_EXPONENTS = {'KB': 0, 'MB': 1, 'GB': 2, 'TB': 3}
 # Build a translation table for serial numbers, to remove garbage
 # VMware puts in.
@@ -343,7 +338,8 @@ def checkin(request):
     else:
         machine.console_user = None
 
-    machine.activity = any(report_data.get(s) for s in UPDATE_META.keys())
+    activity_keys = ('AppleUpdates', 'ManagedInstalls', 'InstallResults', 'RemovalResults')
+    machine.activity = any(report_data.get(s) for s in activity_keys)
 
     # Check errors and warnings.
     machine.errors = len(report_data.get("Errors", []))

--- a/server/plugins/pending3rdpartyupdates/pending3rdpartyupdates.py
+++ b/server/plugins/pending3rdpartyupdates/pending3rdpartyupdates.py
@@ -4,7 +4,7 @@ from django.db.models import Count
 from django.shortcuts import get_object_or_404
 
 import sal.plugin
-from server.models import PendingUpdate
+from server.models import InstalledUpdate
 
 
 class Pending3rdPartyUpdates(sal.plugin.Widget):
@@ -16,8 +16,8 @@ class Pending3rdPartyUpdates(sal.plugin.Widget):
     def get_context(self, queryset, **kwargs):
         context = self.super_get_context(queryset, **kwargs)
         updates = (
-            PendingUpdate.objects
-            .filter(machine__in=queryset)
+            InstalledUpdate.objects
+            .filter(machine__in=queryset, installed=False)
             .values('update', 'update_version', 'display_name')
             .annotate(count=Count('update')))
 
@@ -32,14 +32,15 @@ class Pending3rdPartyUpdates(sal.plugin.Widget):
         except ValueError:
             return None, None
 
-        machines = machines.filter(pending_updates__update=update_name,
-                                   pending_updates__update_version=update_version)
+        machines = machines.filter(installed_updates__update=update_name,
+                                   installed_updates__update_version=update_version,
+                                   installed=False)
 
         # get the display name of the update
         try:
             display_name = (
-                PendingUpdate.objects
-                .filter(update=update_name, update_version=update_version)
+                InstalledUpdate.objects
+                .filter(update=update_name, update_version=update_version, installed=False)
                 .values('display_name')
                 .first())['display_name']
         except (AttributeError, TypeError):


### PR DESCRIPTION
This issue allowed me to discover several problems with the checkin procedure's `process_managed_items` function. The main fix is detailed below (from the first commit).

The remaining commits are just cleanup and simple refactoring of the same code to make it easier to read the next time somebody needs to get into it.

This also updates the InstallReport and Pending3rdPartyUpdates plugins to no-longer use the PendingUpdate model!

In my testing, I don't see any issues related to #274, but some testing wouldn't hurt ;)

So I unrolled it into separate sections so I could understand what was
going wrong.

What I discovered were a couple of problems:
1. PendingUpdate objects were not going to get created. I imagine
systems predating this code that stopped checking in would have some
left behind, but I don't see how they would have gotten created
otherwise. The problem was that it stopped once it determined it was
processing a ManagedInstall; but a ManagedInstall that is not installed
should generate a InstalledUpdate and a PendingUpdate record.
2. There were some incorrect assumptions about the format of the
different sections of the incoming data that made dictionary lookups
with the `get` method fall back to their default values.

After I started working on it, I realized that the PendingUpdate model
is not needed. The only clients of that model are InstallReport and
Pending3rdPartyUpdate plugins, both of which can be very easily updated
to just use InstalledUpdate filtered for `installed=False`.

So I rewrote the processing to no longer even consider creating
PendingUpdate records. I'll remove that model and all references in a
separate PR.