### PR TITLE
Fix checkin exceptions due to missing key.

### DIFF
--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -533,9 +533,9 @@ def process_managed_items(machine, report_data, uuid, now, datelimit):
     for report_key, result_type in (('InstallResults', 'install'), ('RemovalResults', 'removal')):
         for item in report_data.get(report_key, []):
             kwargs = {'name': item['name'], 'machine': machine}
-            kwargs['update_type'] = 'apple' if item['applesus'] else 'third_party'
+            kwargs['update_type'] = 'apple' if item.get('applesus') else 'third_party'
             kwargs['version'] = item.get('version', '0')
-            kwargs['status'] = 'error' if item['status'] != 0 else result_type
+            kwargs['status'] = 'error' if item.get('status') != 0 else result_type
             kwargs['recorded'] = dateutil.parser.parse(str(item['time'])) if 'time' in item else now
 
             update_history_item, update_history = process_update_history_item(


### PR DESCRIPTION
I was seeing some exceptions in my sal logs:
```
ERROR:django.request:Internal Server Error: /checkin/
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/exception.py", line 39, in inner
    response = get_response(request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/views/decorators/http.py", line 40, in inner
    return func(request, *args, **kwargs)
  File "/home/docker/sal/sal/decorators.py", line 170, in wrap
    return function(request, *args, **kwargs)
  File "/home/docker/sal/server/non_ui_views.py", line 422, in checkin
    process_managed_items(machine, report_data, data.get('uuid'), now, datelimit)
  File "/home/docker/sal/server/non_ui_views.py", line 534, in process_managed_items
    kwargs['update_type'] = 'apple' if item['applesus'] else 'third_party'
KeyError: 'applesus'
```

This solves that.