### PR TITLE
Clean up logging and allow it to be overriden from later overrides.

### DIFF
--- a/docker/settings_import.py
+++ b/docker/settings_import.py
@@ -1,7 +1,11 @@
 #!/usr/bin/python3
-from os import getenv
+
+
 import locale
+from os import getenv
+
 from sal.system_settings import *
+
 
 # Read the DEBUG setting from env var
 try:
@@ -11,6 +15,12 @@ try:
         DEBUG = False
 except Exception:
     DEBUG = False
+
+if DEBUG:
+    # Update the loging config let the Sal logger pass debug events.
+    logging_config = get_sal_logging_config()
+    logging_config['loggers']['sal']['level'] = 'DEBUG'
+    update_sal_logging_config(logging_config)
 
 
 # Read the BASIC_AUTH setting from env var

--- a/docker/settings_import.py
+++ b/docker/settings_import.py
@@ -17,7 +17,7 @@ except Exception:
     DEBUG = False
 
 if DEBUG:
-    # Update the loging config let the Sal logger pass debug events.
+    # Update the loging config to let the Sal logger pass debug events.
     logging_config = get_sal_logging_config()
     logging_config['loggers']['sal']['level'] = 'DEBUG'
     logging_config['loggers']['server']['level'] = 'DEBUG'

--- a/docker/settings_import.py
+++ b/docker/settings_import.py
@@ -20,6 +20,7 @@ if DEBUG:
     # Update the loging config let the Sal logger pass debug events.
     logging_config = get_sal_logging_config()
     logging_config['loggers']['sal']['level'] = 'DEBUG'
+    logging_config['loggers']['server']['level'] = 'DEBUG'
     update_sal_logging_config(logging_config)
 
 

--- a/sal/decorators.py
+++ b/sal/decorators.py
@@ -258,5 +258,5 @@ def handle_access(request, group_type, group_id):
 
     if not has_access(request.user, business_unit):
         logger.warning("%s attempted to access %s for which they have no permissions.",
-                        request.user, group_type)
+                       request.user, group_type)
         raise Http404

--- a/sal/decorators.py
+++ b/sal/decorators.py
@@ -19,6 +19,9 @@ from django.views.generic import View
 from server.models import BusinessUnit, Machine, MachineGroup, ProfileLevel
 
 
+logger = logging.getLogger(__name__)
+
+
 def class_login_required(cls):
     """Class decorator for View subclasses to restrict to logged in."""
     decorator = method_decorator(login_required)
@@ -254,6 +257,6 @@ def handle_access(request, group_type, group_id):
         _, business_unit = get_business_unit_by(models[group_type], group_id=group_id)
 
     if not has_access(request.user, business_unit):
-        logging.warning("%s attempted to access %s for which they have no permissions.",
+        logger.warning("%s attempted to access %s for which they have no permissions.",
                         request.user, group_type)
         raise Http404

--- a/sal/plugin.py
+++ b/sal/plugin.py
@@ -47,6 +47,9 @@ DEPRECATED_PAGES = {
     'machine': 'machine_detail'}
 
 
+logger = logging.getLogger(__name__)
+
+
 class OSFamilies():
     chromeos = "ChromeOS"
     darwin = "Darwin"
@@ -540,7 +543,7 @@ class PluginManager():
         for plugin in plugins:
             if plugin.plugin_object:
                 if not isinstance(plugin.plugin_object, BasePlugin):
-                    logging.warning(
+                    logger.warning(
                         "Plugin '%s' needs to be updated to subclass a Sal Plugin!", plugin.name)
                     plugin.plugin_object = OldPluginAdapter(plugin.plugin_object)
 

--- a/sal/system_settings.py
+++ b/sal/system_settings.py
@@ -253,6 +253,11 @@ _SAL_LOGGING_CONFIG = {
             'level': 'ERROR',
             'propagate': False,
         },
+        'server': {
+            'handlers': ['console'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
     }
 }
 

--- a/sal/system_settings.py
+++ b/sal/system_settings.py
@@ -1,3 +1,4 @@
+import logging.config
 import os
 
 
@@ -200,7 +201,34 @@ INSTALLED_APPS = (
     'django_filters'
 )
 
-LOGGING = {
+
+def update_sal_logging_config(config):
+    """Reset Sal logging to use config
+
+    In most cases, call `get_sal_logging` first to get the existing
+    config, update it, and then call this function.
+
+    args:
+        config (dict): Config to use, following the
+            logging.config.dictConfig format.
+    """
+    global _SAL_LOGGING_CONFIG
+    _SAL_LOGGING_CONFIG = config
+    logging.config.dictConfig(_SAL_LOGGING_CONFIG)
+
+
+def get_sal_logging_config():
+    """Return the current logging config for Sal
+
+    returns:
+        dict following the logging.config.dictConfig format.
+    """
+    return _SAL_LOGGING_CONFIG
+
+
+# Zero out all of Django's logging decisions. It's easier this way.
+LOGGING_CONFIG = None
+_SAL_LOGGING_CONFIG = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
@@ -208,30 +236,31 @@ LOGGING = {
             'format': "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
             'datefmt': "%d/%b/%Y %H:%M:%S"
         },
-        'simple': {
-            'format': '%(levelname)s %(message)s'
-        },
     },
     'handlers': {
-        'file': {
-            'level': 'ERROR',
-            'class': 'logging.FileHandler',
-            'filename': 'sal.log',
+        'console': {
+            'class': 'logging.StreamHandler',
             'formatter': 'verbose'
         },
     },
     'loggers': {
-        'django': {
-            'handlers': ['file'],
-            'propagate': True,
+        '': {
+            'handlers': ['console'],
             'level': 'ERROR',
         },
         'sal': {
-            'handlers': ['file'],
+            'handlers': ['console'],
             'level': 'ERROR',
+            'propagate': False,
         },
     }
 }
+
+
+# Do an initial configuration of logging
+update_sal_logging_config(_SAL_LOGGING_CONFIG)
+
+
 BOOTSTRAP3 = {
     'set_placeholder': False,
 }

--- a/sal/system_settings.py
+++ b/sal/system_settings.py
@@ -232,7 +232,7 @@ _SAL_LOGGING_CONFIG = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
-        'verbose': {
+        'sal_format': {
             'format': "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
             'datefmt': "%d/%b/%Y %H:%M:%S"
         },
@@ -240,7 +240,7 @@ _SAL_LOGGING_CONFIG = {
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
-            'formatter': 'verbose'
+            'formatter': 'sal_format'
         },
     },
     'loggers': {
@@ -258,6 +258,7 @@ _SAL_LOGGING_CONFIG = {
             'level': 'ERROR',
             'propagate': False,
         },
+        # Configure additional Sal apps for logging here.
     }
 }
 

--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -34,6 +34,8 @@ IGNORE_PREFIXES = server.utils.get_django_setting('IGNORE_FACTS', [])
 # VMware puts in.
 SERIAL_TRANSLATE = {ord(c): None for c in '+/'}
 
+logger = logging.getLogger(__name__)
+
 
 @login_required
 def tableajax(request, plugin_name, data, group_type='all', group_id=None):
@@ -282,10 +284,10 @@ def checkin(request):
             # If the report server is down, don't halt all submissions
             server.utils.send_report()
         except Exception as e:
-            logging.debug(e)
+            logger.debug(e)
 
     msg = f"Sal report submitted for {machine.serial}"
-    logging.debug(msg)
+    logger.debug(msg)
     return HttpResponse(msg)
 
 

--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -302,6 +302,7 @@ def process_checkin_serial(serial):
             machine = Machine.objects.get(serial=serial)
         except Machine.DoesNotExist:
             machine = Machine(serial=serial)
+            logger.debug("Creating new machine for checkin: '%s'", serial)
     else:
         machine = get_object_or_404(Machine, serial=serial)
     return machine

--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -26,10 +26,6 @@ from server.models import (Machine, Fact, HistoricalFact, MachineGroup, Message,
                            ManagedItem, MachineDetailPlugin, ManagementSource, ManagedItemHistory)
 
 
-if settings.DEBUG:
-    logging.basicConfig(level=logging.INFO)
-
-
 # The database probably isn't going to change while this is loaded.
 IS_POSTGRES = server.utils.is_postgres()
 HISTORICAL_FACTS = server.utils.get_django_setting('HISTORICAL_FACTS', [])

--- a/server/settings_views.py
+++ b/server/settings_views.py
@@ -16,10 +16,6 @@ from server import forms
 from server.models import ProfileLevel, Plugin, ApiKey, Report, MachineDetailPlugin, UserProfile
 from server.views import index as index_view
 
-if settings.DEBUG:
-    import logging
-    logging.basicConfig(level=logging.INFO)
-
 
 # The database probably isn't going to change while this is loaded.
 IS_POSTGRES = utils.is_postgres()

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,7 +1,6 @@
 import hashlib
 import itertools
 import json
-import logging
 import os
 import pathlib
 import plistlib
@@ -496,9 +495,6 @@ def load_default_plugins():
 
 def reload_plugins_model():
     """Remove now-absent plugins from db, refresh defaults if needed."""
-    if settings.DEBUG:
-        logging.getLogger('yapsy').setLevel(logging.WARNING)
-
     load_default_plugins()
     found = {plugin.name for plugin in PluginManager().get_all_plugins()}
     for model in (Plugin, Report, MachineDetailPlugin):

--- a/server/views.py
+++ b/server/views.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from collections import defaultdict
 
@@ -28,6 +29,9 @@ STATUSES = {
     'PENDING': 'btn-info',
     'ERROR': 'btn-danger',
     'UNKNOWN': 'btn-default'}
+
+
+logger = logging.getLogger(__name__)
 
 
 @login_required
@@ -344,6 +348,7 @@ def machine_detail(request, **kwargs):
             try:
                 data = json.loads(item.data)
             except json.decoder.JSONDecodeError:
+                logger.error('Managed item JSON is invalid: %s', item.data)
                 data = {}
         else:
             data = {}

--- a/server/views.py
+++ b/server/views.py
@@ -17,10 +17,6 @@ from server.models import (BusinessUnit, MachineGroup, Machine, UserProfile, Rep
 from server.non_ui_views import process_plugin
 from server import utils
 
-if settings.DEBUG:
-    import logging
-    logging.basicConfig(level=logging.INFO)
-
 
 # The database probably isn't going to change while this is loaded.
 IS_POSTGRES = utils.is_postgres()

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,4 +1,4 @@
-cffi==1.7.0
+cffi==1.12.3
 coreapi==2.3.1
 cryptography==2.4.2
 Django==2.1.11

--- a/utils/text_utils.py
+++ b/utils/text_utils.py
@@ -1,6 +1,7 @@
 import base64
 import binascii
 import bz2
+import logging
 import plistlib
 import re
 from typing import Any, Union, Dict
@@ -9,6 +10,9 @@ from xml.parsers.expat import ExpatError
 
 Plist = Dict[str, Any]
 Text = Union[str, bytes]
+
+
+logger = logging.getLogger(__name__)
 
 
 def class_to_title(text):
@@ -74,12 +78,14 @@ def decode_submission_data(data: Text, compression: str = '') -> bytes:
         try:
             data = base64.b64decode(data)
         except (TypeError, binascii.Error):
+            logger.warning("Submission data failed base 64 decoding: '%s'", data)
             data = b''
 
     if 'bz2' in compression:
         try:
             data = bz2.decompress(data)
         except IOError:
+            logger.warning("Submission data failed decompression: '%s'", data)
             data = b''
 
     # Make sure we're returning bytes, even if the compression
@@ -98,6 +104,7 @@ def submission_plist_loads(data: Text, compression: str = '') -> Plist:
     try:
         plist = plistlib.loads(data)
     except (plistlib.InvalidFileException, ExpatError):
+        logger.warning("Submission data failed plist deserialization: '%s'", data)
         plist = {}
     return plist
 


### PR DESCRIPTION
To see an example of making changes, see the docker/settings_import.py
file.

I'll definitely need some eyes on this.

This came about because I'm troubleshooting the sal-saml variant, and if you turn on debug you get a mess of gajillions of yapsy log messages. It turns out, there are a bunch of places where logging was getting reconfigured all over the project, which made it very difficult to get anything configured.

Now, anything should be able to add specific loggers or tweak the existing ones by using the functions added to system_settings.

And maybe THAT needs to really be in utils, but this is a good start.