### PR TITLE
Fix history key lookup error for absent histories.

### DIFF
--- a/server/templates/server/machine_detail.html
+++ b/server/templates/server/machine_detail.html
@@ -297,7 +297,7 @@ $( document ).ready(function() {
                   {% endfor %}
                 </dl>
                 {% with history_key=item.management_source.name|cat:'||'|cat:item.name %}
-                {% with history=histories|dict_lookup:history_key %}
+                {% with history=histories|dict_get:history_key %}
                 {% if history %}
                 <table class="table table-striped">
                     <th>Status</th>

--- a/server/templatetags/dashboard_extras.py
+++ b/server/templatetags/dashboard_extras.py
@@ -115,8 +115,13 @@ def sort(data):
 
 
 @register.filter
-def dict_lookup(hash, key):
-    return hash[key]
+def dict_lookup(d, k):
+    return d[k]
+
+
+@register.filter
+def dict_get(d, k):
+    return d.get(k)
 
 
 @register.filter


### PR DESCRIPTION
Also, stop using a builtin name `hash`.