### PR TITLE
Check for a None value before trying to convert to int

### DIFF
--- a/server/migrations/0083_auto_20190215_1009.py
+++ b/server/migrations/0083_auto_20190215_1009.py
@@ -14,8 +14,12 @@ def convert_drives_to_int_bytes(apps, schema_editor):
     for machine in Machine.objects.all():
         # Django already converted str to int for us, but we cast back
         # to int just to be safe.
-        machine.hd_total = int(machine.hd_total * 1024.0)
-        machine.hd_space = int(machine.hd_space * 1024.0)
+        if machine.hd_total:
+            machine.hd_total = int(machine.hd_total * 1024.0)
+
+        if machine.hd_space:
+            machine.hd_space = int(machine.hd_space * 1024.0)
+
         machine.save()
 
 


### PR DESCRIPTION
When doing the migration from sal 3 to sal 4, I got the following error:

`TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'`

I narrowed it done to the migration in this diff. It is trying to blindly convert `machine.hd_total` to an int, so if it is `None`, it will cause the migration to fail.