### PR TITLE
V4 Regression add default port for memcached.

### DIFF
--- a/docker/settings.py
+++ b/docker/settings.py
@@ -22,7 +22,7 @@ if 'MEMCACHED_PORT_11211_TCP_ADDR' in os.environ:
             'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
             'LOCATION': [
                 '%s:%s' % (os.environ['MEMCACHED_PORT_11211_TCP_ADDR'],
-                           os.environ['MEMCACHED_PORT_11211_TCP_PORT']),
+                           os.environ['MEMCACHED_PORT_11211_TCP_PORT'], '11211'),
             ]
         }
     }


### PR DESCRIPTION
As title suggests on v3 you default to this value so the flag `MEMCACHED_PORT_11211_TCP_PORT` is not required to be set. 

