### PR TITLE
Change filter_queryset_by_group to do filters in one operation

### DIFF
--- a/inventory/views.py
+++ b/inventory/views.py
@@ -127,11 +127,6 @@ class GroupMixin():
         if self.group_instance:
             filter_path = self.access_filter[queryset.model][self.classes[group_type]]
 
-            # If filter_path is Machine there is nothing to filter on.
-            if filter_path:
-                kwargs = {filter_path: self.group_instance}
-                queryset = queryset.filter(**kwargs)
-
         # Remove undeployed machines from the results.
         # It's important that we are filtering for deployed machines
         # here rather than excluding undeployed machines-you get
@@ -143,7 +138,12 @@ class GroupMixin():
         # construct the keyword argument name to filter.
         deployed_filter = '{}{}deployed'.format(
             self.access_filter[queryset.model][Machine], '' if queryset.model is Machine else '__')
-        queryset = queryset.filter(**{deployed_filter: True})
+        # If filter_path is Machine there is nothing to filter on.
+        if filter_path:
+            kwargs = {filter_path: self.group_instance}
+            queryset = queryset.filter(**kwargs, **{deployed_filter: True})
+        else:
+            queryset = queryset.filter(**{deployed_filter: True})
 
         return queryset
 

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -124,6 +124,7 @@ class GroupMixin():
         # No need to filter if group_instance is None.
         group_type = self.kwargs['group_type']
 
+        filter_path = None
         if self.group_instance:
             filter_path = self.access_filter[queryset.model][self.classes[group_type]]
 


### PR DESCRIPTION
This change combines the filters into one operation to avoid doing a double inner join, which seemed to decreased perf on large data sets. See https://code.djangoproject.com/ticket/29196

It may not be appropriate for *every* query, but it seems to work well here.

Below are the before and after with this change on the machine inventory view (`/inventory/machine/ID`:

Before:

```
SELECT DISTINCT
  "inventory_application"."id",
  "inventory_application"."name",
  "inventory_application"."bundleid",
  "inventory_application"."bundlename"
FROM
  "inventory_application"
  INNER JOIN "inventory_inventoryitem" ON ("inventory_application"."id" = "inventory_inventoryitem"."application_id")
  INNER JOIN "inventory_inventoryitem" T4 ON ("inventory_application"."id" = T4. "application_id")
  INNER JOIN "server_machine" T5 ON (T4. "machine_id" = T5. "id")
WHERE ("inventory_inventoryitem"."machine_id" = 29884
  AND T5. "deployed" = TRUE
  AND NOT ("inventory_application"."bundleid"::text ~ 'com\.vmware\.proxyApp\..*|com\.parallels\.winapp\..*'))
ORDER BY
  "inventory_application"."name" ASC
LIMIT 20

 Planning time: 1.607 ms
 Execution time: 29895.624 ms


   id   |            name            |                   bundleid                   |         bundlename
-------+----------------------------+----------------------------------------------+----------------------------
  1314 | 1Password 7                | com.agilebits.onepassword7                   | 1Password 7
  1317 | 1Password Extension Helper | 2BUA8C4S2C.com.agilebits.onepassword7-helper | 1Password Extension Helper
  1311 | 1Password Launcher         | com.agilebits.onepassword7-launcher          | 1Password Launcher
   269 | 50onPaletteServer          | com.apple.50onPaletteIM                      | Japanese Kana Palette
   252 | ABAssistantService         | com.apple.ABAssistantService                 | ABAssistantService
   263 | About This Mac             | com.apple.AboutThisMacLauncher               | About This Mac
   176 | AccessibilityVisualsAgent  | com.apple.AccessibilityVisualsAgent          | AccessibilityVisualsAgent
 18596 | AcCoreConsole              | com.autodesk.AcCoreConsole                   | AcCoreConsole
     8 | Activity Monitor           | com.apple.ActivityMonitor                    | Activity Monitor
   327 | AddPrinter                 | com.apple.print.add                          | AddPrinter
   258 | AddressBookManager         | com.apple.AddressBook.abd                    | AddressBookManager
   193 | AddressBookSourceSync      | com.apple.AddressBookSourceSync              | AddressBookSourceSync
    44 | AddressBookSync            | com.apple.AddressBook.sync                   | AddressBookSync
   107 | AddressBookUrlForwarder    | com.apple.AddressBook.UrlForwarder           | AddressBookUrlForwarder
    70 | AinuIM                     | com.apple.inputmethod.Ainu                   | AinuIM
   205 | AirDrop                    | com.apple.finder.Open-AirDrop                | AirDrop
    86 | AirPlayUIAgent             | com.apple.AirPlayUIAgent                     | AirPlayUIAgent
   340 | AirPort Base Station Agent | com.apple.AirPortBaseStationAgent            | AirPort Base Station Agent
    72 | AirPort Utility            | com.apple.airport.airportutility             | AirPort Utility
     4 | AirScanLegacyDiscovery     | com.apple.print.AirScanLegacyDiscovery       | AirScanLegacyDiscovery
(20 rows)
```

After:
```
SELECT DISTINCT
  "inventory_application"."id",
  "inventory_application"."name",
  "inventory_application"."bundleid",
  "inventory_application"."bundlename"
FROM
  "inventory_application"
  INNER JOIN "inventory_inventoryitem" ON ("inventory_application"."id" = "inventory_inventoryitem"."application_id")
  INNER JOIN "server_machine" ON ("inventory_inventoryitem"."machine_id" = "server_machine"."id")
WHERE ("inventory_inventoryitem"."machine_id" = 29884
  AND "server_machine"."deployed" = TRUE
  AND NOT ("inventory_application"."bundleid"::text ~ 'com\.vmware\.proxyApp\..*|com\.parallels\.winapp\..*'))
ORDER BY
  "inventory_application"."name" ASC
LIMIT 20;


Planning time: 1.112 ms
Execution time: 5.052 ms
(34 rows)

  id   |            name            |                   bundleid                   |         bundlename
-------+----------------------------+----------------------------------------------+----------------------------
  1314 | 1Password 7                | com.agilebits.onepassword7                   | 1Password 7
  1317 | 1Password Extension Helper | 2BUA8C4S2C.com.agilebits.onepassword7-helper | 1Password Extension Helper
  1311 | 1Password Launcher         | com.agilebits.onepassword7-launcher          | 1Password Launcher
   269 | 50onPaletteServer          | com.apple.50onPaletteIM                      | Japanese Kana Palette
   252 | ABAssistantService         | com.apple.ABAssistantService                 | ABAssistantService
   263 | About This Mac             | com.apple.AboutThisMacLauncher               | About This Mac
   176 | AccessibilityVisualsAgent  | com.apple.AccessibilityVisualsAgent          | AccessibilityVisualsAgent
 18596 | AcCoreConsole              | com.autodesk.AcCoreConsole                   | AcCoreConsole
     8 | Activity Monitor           | com.apple.ActivityMonitor                    | Activity Monitor
   327 | AddPrinter                 | com.apple.print.add                          | AddPrinter
   258 | AddressBookManager         | com.apple.AddressBook.abd                    | AddressBookManager
   193 | AddressBookSourceSync      | com.apple.AddressBookSourceSync              | AddressBookSourceSync
    44 | AddressBookSync            | com.apple.AddressBook.sync                   | AddressBookSync
   107 | AddressBookUrlForwarder    | com.apple.AddressBook.UrlForwarder           | AddressBookUrlForwarder
    70 | AinuIM                     | com.apple.inputmethod.Ainu                   | AinuIM
   205 | AirDrop                    | com.apple.finder.Open-AirDrop                | AirDrop
    86 | AirPlayUIAgent             | com.apple.AirPlayUIAgent                     | AirPlayUIAgent
   340 | AirPort Base Station Agent | com.apple.AirPortBaseStationAgent            | AirPort Base Station Agent
    72 | AirPort Utility            | com.apple.airport.airportutility             | AirPort Utility
     4 | AirScanLegacyDiscovery     | com.apple.print.AirScanLegacyDiscovery       | AirScanLegacyDiscovery
(20 rows)
```

Note the only sql difference here is that there is no redundant `INNER JOIN` on `inventory_inventoryitem`