### PR TITLE
Cleanup plugin code

### DIFF
--- a/sal/plugin.py
+++ b/sal/plugin.py
@@ -391,10 +391,14 @@ class PluginManager():
     """
 
     def __init__(self):
-        self.manager = yapsy.PluginManager.PluginManager()
-        self.manager.setPluginPlaces([settings.PLUGIN_DIR, os.path.join(
-            settings.PROJECT_DIR, 'server/plugins')])
-        self.manager.collectPlugins()
+        # We can use a PluginManagerSingleton to avoid costly startup
+        # and plugin loading.
+        self.manager = yapsy.PluginManager.PluginManagerSingleton.get()
+        # No need to recollect if it has already been done.
+        if not self.manager.category_mapping.get('Default'):
+            self.manager.setPluginPlaces([settings.PLUGIN_DIR, os.path.join(
+                settings.PROJECT_DIR, 'server/plugins')])
+            self.manager.collectPlugins()
 
     def get_plugin_by_name(self, name):
         """Search the configured plugin sources for a plugin, by name.

--- a/sal/tests/test_decorators.py
+++ b/sal/tests/test_decorators.py
@@ -2,13 +2,16 @@
 
 
 from django.http.response import Http404, HttpResponseServerError
+from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase, RequestFactory
 from django.urls import reverse
 
-from sal.decorators import *
+from sal.decorators import (
+    access_required, has_access, is_global_admin, staff_required, required_level, ProfileLevel,
+    key_auth_required)
 from sal.decorators import get_business_unit_by as func_get_business_unit
-from server.models import *
+from server.models import BusinessUnit, MachineGroup, Machine
 
 
 SUCCESS = 'Nice work, amigo.'

--- a/server/migrations/0058_auto_20170822_1430.py
+++ b/server/migrations/0058_auto_20170822_1430.py
@@ -13,11 +13,10 @@ from utils import text_utils
 
 def update_os_families(apps, schema_editor):
     enabled_plugins = Plugin.objects.all()
-    manager = sal.plugin.PluginManager()
     enabled_plugins = apps.get_model("server", "MachineDetailPlugin")
     for item in enabled_plugins.objects.all():
         default_families = ['Darwin', 'Windows', 'Linux', 'ChromeOS']
-        plugin = manager.get_plugin_by_name(item.name)
+        plugin = sal.plugin.PluginManager.get_plugin_by_name(item.name)
         if plugin:
             try:
                 supported_os_families = plugin.get_supported_os_families()

--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -136,7 +136,7 @@ def process_plugin(request, plugin_name, group_type='all', group_id=None):
         model = Report
     else:
         model = MachineDetailPlugin
-        get_object_or_404(model, name=plugin_name)
+    get_object_or_404(model, name=plugin_name)
 
     return plugin
 

--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -62,7 +62,7 @@ def tableajax(request, plugin_name, data, group_type='all', group_id=None):
             order_name = column['name']
             break
 
-    plugin_object = process_plugin(request, plugin_name, group_type, group_id)
+    plugin_object = process_plugin(plugin_name, group_type, group_id)
     queryset = plugin_object.get_queryset(
         request, group_type=group_type, group_id=group_id)
     machines, _ = plugin_object.filter_machines(queryset, data)
@@ -117,12 +117,12 @@ def tableajax(request, plugin_name, data, group_type='all', group_id=None):
 
 @login_required
 def plugin_load(request, plugin_name, group_type='all', group_id=None):
-    plugin_object = process_plugin(request, plugin_name, group_type, group_id)
+    plugin_object = process_plugin(plugin_name, group_type, group_id)
     return HttpResponse(
         plugin_object.widget_content(request, group_type=group_type, group_id=group_id))
 
 
-def process_plugin(request, plugin_name, group_type='all', group_id=None):
+def process_plugin(plugin_name, group_type='all', group_id=None):
     plugin = PluginManager.get_plugin_by_name(plugin_name)
 
     # Ensure that a plugin was instantiated before proceeding.
@@ -143,7 +143,7 @@ def process_plugin(request, plugin_name, group_type='all', group_id=None):
 
 @login_required
 def export_csv(request, plugin_name, data, group_type='all', group_id=None):
-    plugin_object = process_plugin(request, plugin_name, group_type, group_id)
+    plugin_object = process_plugin(plugin_name, group_type, group_id)
     queryset = plugin_object.get_queryset(
         request, group_type=group_type, group_id=group_id)
     machines, title = plugin_object.filter_machines(queryset, data)

--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -123,7 +123,7 @@ def plugin_load(request, plugin_name, group_type='all', group_id=None):
 
 
 def process_plugin(request, plugin_name, group_type='all', group_id=None):
-    plugin = PluginManager().get_plugin_by_name(plugin_name)
+    plugin = PluginManager.get_plugin_by_name(plugin_name)
 
     # Ensure that a plugin was instantiated before proceeding.
     if not plugin:
@@ -157,7 +157,6 @@ def preflight_v2(request):
     """Find plugins that have embedded preflight scripts."""
     # Load in the default plugins if needed
     server.utils.load_default_plugins()
-    manager = PluginManager()
     output = []
     # Old Sal scripts just do a GET; just send everything in that case.
     os_family = None if request.method != 'POST' else request.POST.get('os_family')
@@ -166,7 +165,7 @@ def preflight_v2(request):
     enabled_plugins = Plugin.objects.all()
     enabled_detail_plugins = MachineDetailPlugin.objects.all()
     for enabled_plugin in itertools.chain(enabled_reports, enabled_plugins, enabled_detail_plugins):
-        plugin = manager.get_plugin_by_name(enabled_plugin.name)
+        plugin = PluginManager.get_plugin_by_name(enabled_plugin.name)
         if not plugin:
             continue
         if os_family is None or os_family in plugin.get_supported_os_families():
@@ -181,7 +180,7 @@ def preflight_v2(request):
 @key_auth_required
 def preflight_v2_get_script(request, plugin_name, script_name):
     output = []
-    plugin = PluginManager().get_plugin_by_name(plugin_name)
+    plugin = PluginManager.get_plugin_by_name(plugin_name)
     if plugin:
         content = server.utils.get_plugin_scripts(plugin, script_name=script_name)
         if content:

--- a/server/settings_views.py
+++ b/server/settings_views.py
@@ -276,10 +276,12 @@ def plugin_disable(request, plugin_id):
 def plugin_enable(request, plugin_name):
     # only do this if there isn't a plugin already with the name
     try:
-        plugin = Plugin.objects.get(name=plugin_name)
+        _ = Plugin.objects.get(name=plugin_name)
     except Plugin.DoesNotExist:
-        plugin = Plugin(name=plugin_name, order=utils.unique_plugin_order())
-        plugin.save()
+        plugin = sal.plugin.PluginManager.get_plugin_by_name(plugin_name)
+        if plugin:
+            sal_plugin = Plugin(name=plugin_name, order=utils.unique_plugin_order())
+            sal_plugin.save()
     return redirect('plugins_page')
 
 
@@ -310,11 +312,9 @@ def machine_detail_plugin_disable(request, plugin_id):
 def machine_detail_plugin_enable(request, plugin_name):
     # only do this if there isn't a plugin already with the name
     try:
-        plugin = MachineDetailPlugin.objects.get(name=plugin_name)
+        _ = MachineDetailPlugin.objects.get(name=plugin_name)
     except MachineDetailPlugin.DoesNotExist:
-        manager = sal.plugin.PluginManager()
-
-        plugin = manager.get_plugin_by_name(plugin_name)
+        plugin = sal.plugin.PluginManager.get_plugin_by_name(plugin_name)
         if plugin:
             db_plugin = MachineDetailPlugin(
                 name=plugin_name, order=utils.unique_plugin_order(plugin_type='machine_detail'))
@@ -335,10 +335,12 @@ def settings_report_disable(request, plugin_id):
 def settings_report_enable(request, plugin_name):
     # only do this if there isn't a plugin already with the name
     try:
-        plugin = Report.objects.get(name=plugin_name)
+        _ = Report.objects.get(name=plugin_name)
     except Report.DoesNotExist:
-        plugin = Report(name=plugin_name)
-        plugin.save()
+        plugin = sal.plugin.PluginManager.get_plugin_by_name(plugin_name)
+        if plugin:
+            report = Report(name=plugin_name)
+            report.save()
     return redirect('settings_reports')
 
 

--- a/server/settings_views.py
+++ b/server/settings_views.py
@@ -312,7 +312,6 @@ def machine_detail_plugin_enable(request, plugin_name):
     try:
         plugin = MachineDetailPlugin.objects.get(name=plugin_name)
     except MachineDetailPlugin.DoesNotExist:
-        enabled_plugins = MachineDetailPlugin.objects.all()  # noqa: F841
         manager = sal.plugin.PluginManager()
 
         plugin = manager.get_plugin_by_name(plugin_name)

--- a/server/tests/test_non_ui_views.py
+++ b/server/tests/test_non_ui_views.py
@@ -16,10 +16,11 @@ from django.test import TestCase, Client
 from django.utils.timezone import now
 
 import server.utils
+from sal.plugin import Widget, ReportPlugin, DetailPlugin
 from server import non_ui_views
 from server.models import (
     MachineGroup, Machine, ManagementSource, ManagedItem, ManagedItemHistory, Fact, HistoricalFact,
-    Message)
+    Message, Plugin, Report, MachineDetailPlugin)
 
 
 class CheckinDataTest(TestCase):
@@ -497,3 +498,54 @@ class CheckinHelperTest(TestCase):
     def test_no_add_new_machine(self):
         """Ensure 404 is raised when no ADD_NEW_MACHINES."""
         self.assertRaises(Http404, non_ui_views.process_checkin_serial, 'NotInDB')
+
+
+class PluginTest(TestCase):
+
+    def setUp(self):
+        self.widget = Plugin(name='That gum you like is coming back in style', order=0)
+        self.widget.save()
+        self.report_plugin = Report(name='Drymouth')
+        self.report_plugin.save()
+        self.machine_detail_plugin = MachineDetailPlugin(name='Burrito Mojado', order=0)
+        self.machine_detail_plugin.save()
+
+    def test_process_plugin_no_yapsy_plugin(self):
+        """Test that requesting non-existent plugins via URL 404s"""
+        self.assertRaises(Http404, non_ui_views.process_plugin, None, 'Once a moose bit my sister')
+
+    @patch('sal.plugin.PluginManager.get_plugin_by_name')
+    def test_process_widget_not_enabled(self, manager):
+        """Test that requesting disabled plugins via URL 404s"""
+        manager.return_value = Widget()
+        self.assertRaises(Http404, non_ui_views.process_plugin, None, 'Once a moose bit my sister')
+
+    @patch('sal.plugin.PluginManager.get_plugin_by_name')
+    def test_process_report_not_enabled(self, manager):
+        """Test that requesting disabled plugins via URL 404s"""
+        manager.return_value = ReportPlugin()
+        self.assertRaises(Http404, non_ui_views.process_plugin, None, 'Once a moose bit my sister')
+
+    @patch('sal.plugin.PluginManager.get_plugin_by_name')
+    def test_process_detailplugin_not_enabled(self, manager):
+        """Test that requesting disabled detail plugins via URL 404s"""
+        manager.return_value = DetailPlugin()
+        self.assertRaises(Http404, non_ui_views.process_plugin, None, 'Once a moose bit my sister')
+
+    @patch('sal.plugin.PluginManager.get_plugin_by_name')
+    def test_process_widget_enabled(self, manager):
+        """Test that requesting enabled, existing plugins works"""
+        manager.return_value = Widget()
+        self.assertTrue(non_ui_views.process_plugin(None, plugin_name=self.widget.name))
+
+    @patch('sal.plugin.PluginManager.get_plugin_by_name')
+    def test_process_report_enabled(self, manager):
+        """Test that requesting enabled, existing reports works"""
+        manager.return_value = ReportPlugin()
+        self.assertTrue(non_ui_views.process_plugin(None, plugin_name=self.report_plugin.name))
+
+    @patch('sal.plugin.PluginManager.get_plugin_by_name')
+    def test_process_machine_detail_plugin_enabled(self, manager):
+        """Test that requesting enabled, existing detail plugins works"""
+        manager.return_value = DetailPlugin()
+        self.assertTrue(non_ui_views.process_plugin(None, plugin_name=self.machine_detail_plugin.name))

--- a/server/tests/test_non_ui_views.py
+++ b/server/tests/test_non_ui_views.py
@@ -512,40 +512,40 @@ class PluginTest(TestCase):
 
     def test_process_plugin_no_yapsy_plugin(self):
         """Test that requesting non-existent plugins via URL 404s"""
-        self.assertRaises(Http404, non_ui_views.process_plugin, None, 'Once a moose bit my sister')
+        self.assertRaises(Http404, non_ui_views.process_plugin, 'Once a moose bit my sister')
 
     @patch('sal.plugin.PluginManager.get_plugin_by_name')
     def test_process_widget_not_enabled(self, manager):
         """Test that requesting disabled plugins via URL 404s"""
         manager.return_value = Widget()
-        self.assertRaises(Http404, non_ui_views.process_plugin, None, 'Once a moose bit my sister')
+        self.assertRaises(Http404, non_ui_views.process_plugin, 'Once a moose bit my sister')
 
     @patch('sal.plugin.PluginManager.get_plugin_by_name')
     def test_process_report_not_enabled(self, manager):
         """Test that requesting disabled plugins via URL 404s"""
         manager.return_value = ReportPlugin()
-        self.assertRaises(Http404, non_ui_views.process_plugin, None, 'Once a moose bit my sister')
+        self.assertRaises(Http404, non_ui_views.process_plugin, 'Once a moose bit my sister')
 
     @patch('sal.plugin.PluginManager.get_plugin_by_name')
     def test_process_detailplugin_not_enabled(self, manager):
         """Test that requesting disabled detail plugins via URL 404s"""
         manager.return_value = DetailPlugin()
-        self.assertRaises(Http404, non_ui_views.process_plugin, None, 'Once a moose bit my sister')
+        self.assertRaises(Http404, non_ui_views.process_plugin, 'Once a moose bit my sister')
 
     @patch('sal.plugin.PluginManager.get_plugin_by_name')
     def test_process_widget_enabled(self, manager):
         """Test that requesting enabled, existing plugins works"""
         manager.return_value = Widget()
-        self.assertTrue(non_ui_views.process_plugin(None, plugin_name=self.widget.name))
+        self.assertTrue(non_ui_views.process_plugin(plugin_name=self.widget.name))
 
     @patch('sal.plugin.PluginManager.get_plugin_by_name')
     def test_process_report_enabled(self, manager):
         """Test that requesting enabled, existing reports works"""
         manager.return_value = ReportPlugin()
-        self.assertTrue(non_ui_views.process_plugin(None, plugin_name=self.report_plugin.name))
+        self.assertTrue(non_ui_views.process_plugin(plugin_name=self.report_plugin.name))
 
     @patch('sal.plugin.PluginManager.get_plugin_by_name')
     def test_process_machine_detail_plugin_enabled(self, manager):
         """Test that requesting enabled, existing detail plugins works"""
         manager.return_value = DetailPlugin()
-        self.assertTrue(non_ui_views.process_plugin(None, plugin_name=self.machine_detail_plugin.name))
+        self.assertTrue(non_ui_views.process_plugin(plugin_name=self.machine_detail_plugin.name))

--- a/server/tests/test_settings_views.py
+++ b/server/tests/test_settings_views.py
@@ -1,0 +1,124 @@
+"""Beginning of the test setup for non_ui_views"""
+
+
+from unittest.mock import patch
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import TestCase, Client
+
+import server.utils
+from sal.plugin import Widget, ReportPlugin, DetailPlugin
+from server.models import Plugin, Report, MachineDetailPlugin
+
+
+class WidgetSettingsTest(TestCase):
+    """Functional tests for Widget settings views."""
+    fixtures = ['user_fixture.json']
+
+    def setUp(self):
+        self.ga_user = User.objects.get(pk=1)
+        user_profile = self.ga_user.userprofile
+        user_profile.level = 'GA'
+        user_profile.save()
+        settings.BASIC_AUTH = False
+        self.client = Client()
+        self.client.force_login(self.ga_user)
+        self.url = '/settings/plugins/enable'
+        # Avoid sending analytics to the project while testing!
+        server.utils.set_setting('send_data', False)
+        self.widget = Plugin(name='Widget', order=0)
+        self.widget.save()
+        self.report_plugin = Report(name='Report')
+        self.report_plugin.save()
+
+    def test_enable_enabled_widget(self):
+        """Test that enabling an enabled widget does nothing"""
+        self.client.get(f'{self.url}/{self.widget.name}/')
+        self.assertEqual(Plugin.objects.count(), 1)
+
+    @patch('sal.plugin.PluginManager.get_plugin_by_name')
+    def test_enable_disabled_widget(self, manager):
+        """Test that enabling a disabled widget works"""
+        # Fake that this plugin has a yapsy file
+        manager.return_value = Widget()
+        self.client.get(f'{self.url}/tacos/')
+        self.assertEqual(Plugin.objects.count(), 2)
+
+    def test_enable_nonexistent_widget(self):
+        """If a plugin does not exist, redirect to plugin list."""
+        self.client.get(f'{self.url}/tacos/')
+        self.assertEqual(Plugin.objects.count(), 1)
+
+
+class DetailPluginSettingsTest(TestCase):
+    """Functional tests for DetailPlugin settings views."""
+    fixtures = ['user_fixture.json']
+
+    def setUp(self):
+        self.ga_user = User.objects.get(pk=1)
+        user_profile = self.ga_user.userprofile
+        user_profile.level = 'GA'
+        user_profile.save()
+        settings.BASIC_AUTH = False
+        self.client = Client()
+        self.client.force_login(self.ga_user)
+        self.url = '/settings/plugins/machinedetail/enable'
+        # Avoid sending analytics to the project while testing!
+        server.utils.set_setting('send_data', False)
+
+    def test_enable_enabled_detail_plugin(self):
+        """Test that enabling an enabled plugin does nothing"""
+        self.client.get(f'{self.url}/MachineDetailSecurity/')
+        self.assertEqual(MachineDetailPlugin.objects.count(), 1)
+
+    @patch('sal.plugin.PluginManager.get_plugin_by_name')
+    def test_enable_disabled_detail_plugin(self, manager):
+        """Test that enabling a disabled detail plugin works"""
+        # Fake that this plugin has a yapsy file
+        manager.return_value = DetailPlugin()
+        self.client.get(f'{self.url}/tacos/')
+        self.assertEqual(MachineDetailPlugin.objects.count(), 2)
+
+    def test_enable_nonexistent_detail_plugin(self):
+        """If a plugin does not exist, redirect to plugin list."""
+        self.client.get(f'{self.url}/tacos/')
+        self.assertEqual(MachineDetailPlugin.objects.count(), 1)
+
+
+class ReportSettingsTest(TestCase):
+    """Functional tests for Report settings views."""
+    fixtures = ['user_fixture.json']
+
+    def setUp(self):
+        self.ga_user = User.objects.get(pk=1)
+        user_profile = self.ga_user.userprofile
+        user_profile.level = 'GA'
+        user_profile.save()
+        settings.BASIC_AUTH = False
+        self.client = Client()
+        self.client.force_login(self.ga_user)
+        self.url = '/settings/plugins/reports/enable'
+        # Avoid sending analytics to the project while testing!
+        server.utils.set_setting('send_data', False)
+
+    def test_enable_enabled_report(self):
+        """Test that enabling an enabled report does nothing"""
+        self.client.get(f'{self.url}/InstallReport/')
+        # There are two included by default.
+        self.assertEqual(Report.objects.count(), 2)
+
+    @patch('sal.plugin.PluginManager.get_plugin_by_name')
+    def test_enable_disabled_report(self, manager):
+        """Test that enabling a disabled report works"""
+        # Fake that this plugin has a yapsy file
+        manager.return_value = ReportPlugin()
+        self.client.get(f'{self.url}/tacos/')
+        # breakpoint()
+        self.assertEqual(Report.objects.count(), 3)
+
+    def test_enable_nonexistent_report(self):
+        """If a plugin does not exist, redirect to plugin list."""
+        self.client.get(f'{self.url}/tacos/')
+        # There are two included by default.
+        self.assertEqual(Report.objects.count(), 2)

--- a/server/utils.py
+++ b/server/utils.py
@@ -617,7 +617,7 @@ def get_report_names():
     return Report.objects.values_list('name', flat=True)
 
 
-def get_plugin_placeholder_markup(plugins, group_type='all', group_id=None):
+def get_plugin_placeholder_markup(group_type='all', group_id=None):
     result = []
     manager = PluginManager()
     hidden = get_hidden_plugins(group_type, group_id)

--- a/server/utils.py
+++ b/server/utils.py
@@ -619,7 +619,7 @@ def get_plugin_placeholder_markup(group_type='all', group_id=None):
     result = []
     hidden = get_hidden_plugins(group_type, group_id)
     group_oses = get_member_oses(group_type, group_id)
-    display_plugins = [p for p in Plugin.objects.order_by('order') if p.name not in hidden]
+    display_plugins = [p for p in Plugin.objects.exclude(name__in=hidden).order_by('order')]
     for enabled_plugin in display_plugins:
         name = enabled_plugin.name
         yapsy_plugin = PluginManager.get_plugin_by_name(name)

--- a/server/utils.py
+++ b/server/utils.py
@@ -613,7 +613,7 @@ def order_plugin_output(plugin_data, group_type='all', group_id=None):
     return plugin_data
 
 
-def get_report_names(plugins):
+def get_report_names():
     return Report.objects.values_list('name', flat=True)
 
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -599,7 +599,7 @@ def get_hidden_plugins(group_type='all', group_id=None):
     return hidden
 
 
-def order_plugin_output(plugin_data, group_type='all', group_id=None):
+def order_plugin_output(plugin_data):
     col_width = 12
     total_width = 0
 
@@ -639,7 +639,7 @@ def get_plugin_placeholder_markup(group_type='all', group_id=None):
                 '</div>\n'.format(name, width, static('img/blue-spinner.gif')))
         result.append({'name': name, 'width': width, 'html': html})
 
-    return order_plugin_output(result, group_type, group_id)
+    return order_plugin_output(result)
 
 
 def get_machine_detail_placeholder_markup(machine):

--- a/server/utils.py
+++ b/server/utils.py
@@ -468,9 +468,8 @@ def run_plugin_processing(machine, report_data):
     enabled_reports = Report.objects.all()
     enabled_plugins = Plugin.objects.all()
     enabled_detail_plugins = MachineDetailPlugin.objects.all()
-    manager = PluginManager()
     for enabled_plugin in itertools.chain(enabled_reports, enabled_plugins, enabled_detail_plugins):
-        plugin = manager.get_plugin_by_name(enabled_plugin.name)
+        plugin = PluginManager.get_plugin_by_name(enabled_plugin.name)
         if plugin:
             plugin.checkin_processor(machine, report_data)
 
@@ -478,9 +477,8 @@ def run_plugin_processing(machine, report_data):
 def run_profiles_plugin_processing(machine, profiles_list):
     enabled_plugins = Plugin.objects.all()
     enabled_detail_plugins = MachineDetailPlugin.objects.all()
-    manager = PluginManager()
     for enabled_plugin in itertools.chain(enabled_plugins, enabled_detail_plugins):
-        plugin = manager.get_plugin_by_name(enabled_plugin.name)
+        plugin = PluginManager.get_plugin_by_name(enabled_plugin.name)
         if plugin:
             plugin.profiles_processor(machine, profiles_list)
 
@@ -495,7 +493,7 @@ def load_default_plugins():
 def reload_plugins_model():
     """Remove now-absent plugins from db, refresh defaults if needed."""
     load_default_plugins()
-    found = {plugin.name for plugin in PluginManager().get_all_plugins()}
+    found = {plugin.name for plugin in PluginManager.get_all_plugins()}
     for model in (Plugin, Report, MachineDetailPlugin):
         _update_plugin_record(model, found)
 
@@ -619,13 +617,12 @@ def get_report_names():
 
 def get_plugin_placeholder_markup(group_type='all', group_id=None):
     result = []
-    manager = PluginManager()
     hidden = get_hidden_plugins(group_type, group_id)
     group_oses = get_member_oses(group_type, group_id)
     display_plugins = [p for p in Plugin.objects.order_by('order') if p.name not in hidden]
     for enabled_plugin in display_plugins:
         name = enabled_plugin.name
-        yapsy_plugin = manager.get_plugin_by_name(name)
+        yapsy_plugin = PluginManager.get_plugin_by_name(name)
         if not yapsy_plugin:
             continue
         # Skip this plugin if the group's members OS families aren't supported

--- a/server/views.py
+++ b/server/views.py
@@ -91,7 +91,7 @@ def index(request):
 
 @login_required
 def machine_list(request, plugin_name, data, group_type='all', group_id=None):
-    plugin_object = process_plugin(request, plugin_name, group_type, group_id)
+    plugin_object = process_plugin(plugin_name, group_type, group_id)
     # queryset = plugin_object.get_queryset(request, group_type=group_type, group_id=group_id)
     # Plugin will raise 404 if bad `data` is passed.
     machines, title = plugin_object.filter_machines(Machine.objects.none(), data)
@@ -111,7 +111,7 @@ def machine_list(request, plugin_name, data, group_type='all', group_id=None):
 @login_required
 def report_load(request, plugin_name, group_type='all', group_id=None):
     groups = utils.get_instance_and_groups(group_type, group_id)
-    plugin_object = process_plugin(request, plugin_name, group_type, group_id)
+    plugin_object = process_plugin(plugin_name, group_type, group_id)
     report_html = plugin_object.widget_content(request, group_type=group_type, group_id=group_id)
     reports = Report.objects.values_list('name', flat=True)
     context = {'output': report_html, 'group_type': group_type, 'group_id': group_id, 'reports':

--- a/server/views.py
+++ b/server/views.py
@@ -63,10 +63,8 @@ def index(request):
 
     # Load in the default plugins if needed
     utils.load_default_plugins()
-    plugins = sal.plugin.PluginManager().get_all_plugins()
-
-    output = utils.get_plugin_placeholder_markup(plugins)
     reports = utils.get_report_names()
+    output = utils.get_plugin_placeholder_markup()
 
     # If the user is GA level, and hasn't decided on a data sending
     # choice, template will reflect this.
@@ -195,11 +193,9 @@ def bu_dashboard(request, **kwargs):
 
     # Load in the default plugins if needed
     utils.load_default_plugins()
-    plugins = sal.plugin.PluginManager().get_all_plugins()
-
     reports = utils.get_report_names()
     output = utils.get_plugin_placeholder_markup(
-        plugins, group_type='business_unit', group_id=business_unit.id)
+        group_type='business_unit', group_id=business_unit.id)
 
     context = {
         'user': request.user,
@@ -239,9 +235,8 @@ def really_delete_machine_group(request, group_id):
 def group_dashboard(request, **kwargs):
     machine_group = kwargs['instance']
     machines = machine_group.machine_set.filter(deployed=True)  # noqa: F841
-    plugins = sal.plugin.PluginManager().get_all_plugins()
     output = utils.get_plugin_placeholder_markup(
-        plugins, group_type='machine_group', group_id=machine_group.id)
+        group_type='machine_group', group_id=machine_group.id)
     reports = utils.get_report_names()
 
     context = {

--- a/server/views.py
+++ b/server/views.py
@@ -65,8 +65,8 @@ def index(request):
     utils.load_default_plugins()
     plugins = sal.plugin.PluginManager().get_all_plugins()
 
-    reports = utils.get_report_names(plugins)
     output = utils.get_plugin_placeholder_markup(plugins)
+    reports = utils.get_report_names()
 
     # If the user is GA level, and hasn't decided on a data sending
     # choice, template will reflect this.
@@ -197,7 +197,7 @@ def bu_dashboard(request, **kwargs):
     utils.load_default_plugins()
     plugins = sal.plugin.PluginManager().get_all_plugins()
 
-    reports = utils.get_report_names(plugins)
+    reports = utils.get_report_names()
     output = utils.get_plugin_placeholder_markup(
         plugins, group_type='business_unit', group_id=business_unit.id)
 
@@ -242,7 +242,7 @@ def group_dashboard(request, **kwargs):
     plugins = sal.plugin.PluginManager().get_all_plugins()
     output = utils.get_plugin_placeholder_markup(
         plugins, group_type='machine_group', group_id=machine_group.id)
-    reports = utils.get_report_names(plugins)
+    reports = utils.get_report_names()
 
     context = {
         'user': request.user,


### PR DESCRIPTION
I discovered that the PluginManager was getting instantiated twice for the dashboard views.
One instance was not really being used, so that got removed.

Then the manager gets instantiated once per widget per reload (including the auto-reload on a timer that happens when you just sit and watch the dashboard), which is excessive! So I figured out how to use the Yapsy PluginManagerSingleton to only do the plugin searching (crawling the filesystem for candidate plugin modules) and loading once.

Because of some name munging, I ended up just extracting the singleton code needed to accomplish our goals rather than subclassing the original.

I removed all of the attribute copying from the yapsy container, because we only use path; this is handled by the singleton at instantiation time, and it is now only done once.

Apparently you could enable widgets and reports that didn’t have an actual yapsy plugin file. This would create DB entries for purposes of tracking enablement and order. This has been corrected, and tests added.

This PR also includes a couple of drive-by cleanups that are too deep in the commit log for me to try to extract into their own PR
1. It cleans up some usage of the access decorators for a few settings views.
2. It cleans up some `from module import *` things that I found.