### PR TITLE
Make historical facts a set, since we only do membership testing.

### DIFF
--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -27,8 +27,8 @@ from server.models import (Machine, Fact, HistoricalFact, MachineGroup, Message,
 
 # The database probably isn't going to change while this is loaded.
 IS_POSTGRES = server.utils.is_postgres()
-HISTORICAL_FACTS = server.utils.get_django_setting('HISTORICAL_FACTS', [])
 IGNORE_PREFIXES = server.utils.get_django_setting('IGNORE_FACTS', [])
+HISTORICAL_FACTS = set(server.utils.get_django_setting('HISTORICAL_FACTS', []))
 # Build a translation table for serial numbers, to remove garbage
 # VMware puts in.
 SERIAL_TRANSLATE = {ord(c): None for c in '+/'}


### PR DESCRIPTION
The extra cost is incurred only once, at startup time, and over tons of
checkins should be a nice little boost in execution time.