### PR TITLE
Use `re.match` instead of `str.startswith` for ignoring facts.

### DIFF
--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 import logging
+import re
 from collections import defaultdict
 
 import dateutil.parser
@@ -28,7 +29,11 @@ from server.models import (Machine, Fact, HistoricalFact, MachineGroup, Message,
 # The database probably isn't going to change while this is loaded.
 IS_POSTGRES = server.utils.is_postgres()
 HISTORICAL_FACTS = server.utils.get_django_setting('HISTORICAL_FACTS', [])
-IGNORE_PREFIXES = server.utils.get_django_setting('IGNORE_FACTS', [])
+if server.utils.get_django_setting('IGNORE_FACTS'):
+    IGNORE_PREFIXES = re.compile(
+        '|'.join(server.utils.get_django_setting('IGNORE_FACTS')))
+else:
+    IGNORE_PREFIXES = None
 # Build a translation table for serial numbers, to remove garbage
 # VMware puts in.
 SERIAL_TRANSLATE = {ord(c): None for c in '+/'}
@@ -394,7 +399,7 @@ def process_munki_extra_keys(management_data, machine, object_queue):
 def process_facts(management_source, management_data, machine, object_queue):
     now = django.utils.timezone.now()
     for fact_name, fact_data in management_data.get('facts', {}).items():
-        if any(fact_name.startswith(p) for p in IGNORE_PREFIXES):
+        if IGNORE_PREFIXES and IGNORE_PREFIXES.match(fact_name):
             continue
 
         object_queue['facts'].append(

--- a/server/tests/test_non_ui_views.py
+++ b/server/tests/test_non_ui_views.py
@@ -8,6 +8,7 @@ import dateutil
 import json
 import plistlib
 import pytz
+import re
 from unittest.mock import patch
 
 from django.conf import settings
@@ -238,7 +239,7 @@ class CheckinFactTest(TestCase):
         self.assertEqual(historical_fact.fact_data, 'Snake Plisskin')
         self.assertEqual(historical_fact.management_source.name, 'Munki')
 
-    @patch('server.non_ui_views.IGNORE_PREFIXES', ['ignore'])
+    @patch('server.non_ui_views.IGNORE_PREFIXES', re.compile('ignore'))
     def test_ignore_facts_setting_works(self):
         """Test the ignore prefixes setting for facts works."""
         machine = Machine.objects.get(serial='C0DEADBEEF')


### PR DESCRIPTION
This tests faster across various permutations of total fact count and
exclusion pattern counts.