### PR TITLE
Settings views access

### DIFF
--- a/licenses/views.py
+++ b/licenses/views.py
@@ -13,7 +13,7 @@ from server.models import *
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def license_index(request):
     """Sal index page for licenses."""
     context = {'request': request,
@@ -24,7 +24,7 @@ def license_index(request):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def new_license(request):
     """Creates a new License object"""
     if request.method == 'POST':
@@ -41,7 +41,7 @@ def new_license(request):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def edit_license(request, license_id):
     license = get_object_or_404(License, pk=license_id)
 
@@ -59,7 +59,7 @@ def edit_license(request, license_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def delete_license(request, license_id):
     license = get_object_or_404(License, pk=license_id)
     license.delete()

--- a/sal/decorators.py
+++ b/sal/decorators.py
@@ -196,7 +196,6 @@ def ga_required(function):
 
     Wrapped function must have the request object as the first argument.
     """
-    # TODO: This can be removed once a class_required_level decoratir is created
     @wraps(function)
     def wrapper(*args, **kwargs):
         if args[0].user.userprofile.level != ProfileLevel.global_admin:

--- a/server/settings_views.py
+++ b/server/settings_views.py
@@ -229,20 +229,18 @@ def settings_machine_detail_plugins(request):
 @login_required
 @ga_required
 def plugin_plus(request, plugin_id):
-    _swap_plugin(request, plugin_id, 1)
+    _swap_plugin(plugin_id, 1)
     return redirect('plugins_page')
 
 
 @login_required
 @ga_required
 def plugin_minus(request, plugin_id):
-    _swap_plugin(request, plugin_id, -1)
+    _swap_plugin(plugin_id, -1)
     return redirect('plugins_page')
 
 
-@login_required
-@ga_required
-def _swap_plugin(request, plugin_id, direction, plugin_model=Plugin):
+def _swap_plugin(plugin_id, direction, plugin_model=Plugin):
     # get current plugin order
     current_plugin = get_object_or_404(plugin_model, pk=plugin_id)
 
@@ -290,14 +288,14 @@ def plugin_enable(request, plugin_name):
 @login_required
 @ga_required
 def machine_detail_plugin_plus(request, plugin_id):
-    _swap_plugin(request, plugin_id, 1, MachineDetailPlugin)
+    _swap_plugin(plugin_id, 1, MachineDetailPlugin)
     return redirect('settings_machine_detail_plugins')
 
 
 @login_required
 @ga_required
 def machine_detail_plugin_minus(request, plugin_id):
-    _swap_plugin(request, plugin_id, -1, MachineDetailPlugin)
+    _swap_plugin(plugin_id, -1, MachineDetailPlugin)
     return redirect('settings_machine_detail_plugins')
 
 

--- a/server/settings_views.py
+++ b/server/settings_views.py
@@ -23,12 +23,11 @@ IS_POSTGRES = utils.is_postgres()
 
 @login_required
 def new_version_never(request):
-    update_notify_date(request)
+    update_notify_date()
     return redirect(reverse('home'))
 
 
-@ga_required
-def update_notify_date(request, length='never'):
+def update_notify_date(length='never'):
     # Don't notify about a new version until there is a new one
     version_report = utils.check_version()
     if version_report['new_version_available']:
@@ -41,13 +40,13 @@ def update_notify_date(request, length='never'):
 
 @login_required
 def new_version_week(request):
-    update_notify_date(request, length=604800)
+    update_notify_date(length=604800)
     return redirect(index_view)
 
 
 @login_required
 def new_version_day(request):
-    update_notify_date(request, length=86400)
+    update_notify_date(length=86400)
     return redirect(index_view)
 
 

--- a/server/settings_views.py
+++ b/server/settings_views.py
@@ -22,6 +22,7 @@ IS_POSTGRES = utils.is_postgres()
 
 
 @login_required
+@ga_required
 def new_version_never(request):
     update_notify_date()
     return redirect(reverse('home'))
@@ -39,12 +40,14 @@ def update_notify_date(length='never'):
 
 
 @login_required
+@ga_required
 def new_version_week(request):
     update_notify_date(length=604800)
     return redirect(index_view)
 
 
 @login_required
+@ga_required
 def new_version_day(request):
     update_notify_date(length=86400)
     return redirect(index_view)
@@ -224,12 +227,14 @@ def settings_machine_detail_plugins(request):
 
 
 @login_required
+@ga_required
 def plugin_plus(request, plugin_id):
     _swap_plugin(request, plugin_id, 1)
     return redirect('plugins_page')
 
 
 @login_required
+@ga_required
 def plugin_minus(request, plugin_id):
     _swap_plugin(request, plugin_id, -1)
     return redirect('plugins_page')

--- a/server/settings_views.py
+++ b/server/settings_views.py
@@ -10,7 +10,7 @@ from django.template.context_processors import csrf
 from django.urls import reverse
 
 import sal.plugin
-from sal.decorators import required_level, staff_required
+from sal.decorators import ga_required, staff_required
 from server import utils
 from server import forms
 from server.models import ProfileLevel, Plugin, ApiKey, Report, MachineDetailPlugin, UserProfile
@@ -27,7 +27,7 @@ def new_version_never(request):
     return redirect(reverse('home'))
 
 
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def update_notify_date(request, length='never'):
     # Don't notify about a new version until there is a new one
     version_report = utils.check_version()
@@ -52,7 +52,7 @@ def new_version_day(request):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 @staff_required
 def manage_users(request):
     try:
@@ -65,7 +65,7 @@ def manage_users(request):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 @staff_required
 def new_user(request):
     c = {}
@@ -86,7 +86,7 @@ def new_user(request):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 @staff_required
 def edit_user(request, user_id):
     the_user = get_object_or_404(User, pk=int(user_id))
@@ -120,7 +120,7 @@ def edit_user(request, user_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def user_add_staff(request, user_id):
     if request.user.id == int(user_id):
         # You shouldn't have been able to get here anyway
@@ -132,7 +132,7 @@ def user_add_staff(request, user_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def user_remove_staff(request, user_id):
     if request.user.id == int(user_id):
         # You shouldn't have been able to get here anyway
@@ -144,7 +144,7 @@ def user_remove_staff(request, user_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def delete_user(request, user_id):
     if request.user.id == int(user_id):
         # You shouldn't have been able to get here anyway
@@ -155,7 +155,7 @@ def delete_user(request, user_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def settings_page(request):
     historical_setting = utils.get_setting('historical_retention')
     historical_setting_form = forms.SettingsHistoricalDataForm(initial={'days': historical_setting})
@@ -171,21 +171,21 @@ def settings_page(request):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def senddata_enable(request):
     utils.set_setting('send_data', True)
     return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def senddata_disable(request):
     utils.set_setting('send_data', False)
     return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def settings_historical_data(request):
     if request.method == 'POST':
         form = forms.SettingsHistoricalDataForm(request.POST)
@@ -200,7 +200,7 @@ def settings_historical_data(request):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def plugins_page(request):
     utils.reload_plugins_model()
     context = {'plugins': utils.get_active_and_inactive_plugins('machines')}
@@ -208,7 +208,7 @@ def plugins_page(request):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def settings_reports(request):
     utils.reload_plugins_model()
     context = {'plugins': utils.get_active_and_inactive_plugins('report')}
@@ -216,7 +216,7 @@ def settings_reports(request):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def settings_machine_detail_plugins(request):
     utils.reload_plugins_model()
     plugins = utils.get_active_and_inactive_plugins('machine_detail')
@@ -237,7 +237,7 @@ def plugin_minus(request, plugin_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def _swap_plugin(request, plugin_id, direction, plugin_model=Plugin):
     # get current plugin order
     current_plugin = get_object_or_404(plugin_model, pk=plugin_id)
@@ -264,7 +264,7 @@ def _swap_plugin(request, plugin_id, direction, plugin_model=Plugin):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def plugin_disable(request, plugin_id):
     plugin = get_object_or_404(Plugin, pk=plugin_id)
     plugin.delete()
@@ -272,7 +272,7 @@ def plugin_disable(request, plugin_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def plugin_enable(request, plugin_name):
     # only do this if there isn't a plugin already with the name
     try:
@@ -284,21 +284,21 @@ def plugin_enable(request, plugin_name):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def machine_detail_plugin_plus(request, plugin_id):
     _swap_plugin(request, plugin_id, 1, MachineDetailPlugin)
     return redirect('settings_machine_detail_plugins')
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def machine_detail_plugin_minus(request, plugin_id):
     _swap_plugin(request, plugin_id, -1, MachineDetailPlugin)
     return redirect('settings_machine_detail_plugins')
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def machine_detail_plugin_disable(request, plugin_id):
     plugin = get_object_or_404(MachineDetailPlugin, pk=plugin_id)
     plugin.delete()
@@ -306,7 +306,7 @@ def machine_detail_plugin_disable(request, plugin_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def machine_detail_plugin_enable(request, plugin_name):
     # only do this if there isn't a plugin already with the name
     try:
@@ -324,7 +324,7 @@ def machine_detail_plugin_enable(request, plugin_name):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def settings_report_disable(request, plugin_id):
     plugin = get_object_or_404(Report, pk=plugin_id)
     plugin.delete()
@@ -332,7 +332,7 @@ def settings_report_disable(request, plugin_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def settings_report_enable(request, plugin_name):
     # only do this if there isn't a plugin already with the name
     try:
@@ -344,7 +344,7 @@ def settings_report_enable(request, plugin_name):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def api_keys(request):
     api_keys = ApiKey.objects.all()
     c = {'user': request.user, 'api_keys': api_keys, 'request': request}
@@ -352,7 +352,7 @@ def api_keys(request):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def new_api_key(request):
     c = {}
     c.update(csrf(request))
@@ -368,7 +368,7 @@ def new_api_key(request):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def display_api_key(request, key_id):
     api_key = get_object_or_404(ApiKey, pk=int(key_id))
     if api_key.has_been_seen:
@@ -381,7 +381,7 @@ def display_api_key(request, key_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def edit_api_key(request, key_id):
     api_key = get_object_or_404(ApiKey, pk=int(key_id))
     c = {}
@@ -399,7 +399,7 @@ def edit_api_key(request, key_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def delete_api_key(request, key_id):
     api_key = get_object_or_404(ApiKey, pk=int(key_id))
     api_key.delete()

--- a/server/views.py
+++ b/server/views.py
@@ -10,7 +10,8 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.context_processors import csrf
 
 import sal.plugin
-from sal.decorators import required_level, ProfileLevel, access_required, is_global_admin
+from sal.decorators import (
+    required_level, ProfileLevel, access_required, is_global_admin, ga_required)
 from server.forms import (BusinessUnitForm, EditUserBusinessUnitForm, EditBusinessUnitForm,
                           MachineGroupForm, EditMachineGroupForm, NewMachineForm)
 from server.models import (BusinessUnit, MachineGroup, Machine, UserProfile, Report, Plugin,
@@ -122,7 +123,7 @@ def report_load(request, plugin_name, group_type='all', group_id=None):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def new_business_unit(request):
     c = {}
     c.update(csrf(request))
@@ -140,7 +141,7 @@ def new_business_unit(request):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def edit_business_unit(request, bu_id):
     business_unit = get_object_or_404(BusinessUnit, pk=int(bu_id))
     c = {}
@@ -165,7 +166,7 @@ def edit_business_unit(request, bu_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def delete_business_unit(request, bu_id):
     business_unit = get_object_or_404(BusinessUnit, pk=int(bu_id))
 
@@ -180,7 +181,7 @@ def delete_business_unit(request, bu_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def really_delete_business_unit(request, bu_id):
     business_unit = get_object_or_404(BusinessUnit, pk=int(bu_id))
     business_unit.delete()
@@ -211,7 +212,7 @@ def bu_dashboard(request, **kwargs):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def delete_machine_group(request, group_id):
     machine_group = get_object_or_404(MachineGroup, pk=int(group_id))
 
@@ -226,7 +227,7 @@ def delete_machine_group(request, group_id):
 
 
 @login_required
-@required_level(ProfileLevel.global_admin)
+@ga_required
 def really_delete_machine_group(request, group_id):
     machine_group = get_object_or_404(MachineGroup, pk=int(group_id))
     business_unit = machine_group.business_unit


### PR DESCRIPTION
This PR ensures that all routable views in the the Sal settings require GA level access.

It also does some cleanup to remove some mistaken decorators on non-view functions and factors out some unused parameters.