### PR TITLE
Address xss

### DIFF
--- a/sal/system_settings.py
+++ b/sal/system_settings.py
@@ -41,7 +41,7 @@ TEMPLATES = [
                 'sal.context_processors.sal_version',
             ],
             'debug': DEBUG,
-            'autoescape': False,
+            'autoescape': True,
         },
     },
 ]

--- a/sal/version.plist
+++ b/sal/version.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>version</key>
-	<string>4.1.0.2109</string>
+	<string>4.1.1.2114</string>
 </dict>
 </plist>

--- a/server/templates/plugins/pendingupdates.html
+++ b/server/templates/plugins/pendingupdates.html
@@ -10,12 +10,10 @@
       {% for item in data %}
       <tr>
         <td>
-          {% with safe_name=item.name|safe %}
-          <a href="{% url 'machine_list' plugin safe_name group_type group_id %}">
+          <a href="{% url 'machine_list' plugin item.name group_type group_id %}">
             {{ item.name }}
             <span class="badge pull-right">{{ item.count }}</span>
           </a>
-          {% endwith %}
         </td>
       </tr>
       {% endfor %}

--- a/server/views.py
+++ b/server/views.py
@@ -93,7 +93,6 @@ def index(request):
 @login_required
 def machine_list(request, plugin_name, data, group_type='all', group_id=None):
     plugin_object = process_plugin(plugin_name, group_type, group_id)
-    # queryset = plugin_object.get_queryset(request, group_type=group_type, group_id=group_id)
     # Plugin will raise 404 if bad `data` is passed.
     machines, title = plugin_object.filter_machines(Machine.objects.none(), data)
     context = {

--- a/set_build_no.sh
+++ b/set_build_no.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-current_version="4.1.0"
+current_version="4.1.1"
 pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd`
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -153,10 +153,8 @@
             {% endblock %}
           </div>
         </div>
-        {% autoescape on %}
-            {% block content %}
-            {% endblock %}
-        {% endautoescape %}
+        {% block content %}
+        {% endblock %}
         <div class="row"><div class="col-md-12"><p class="pull-right">Sal version {{ SAL_VERSION }}</p></div></div>
         </div>
         <!-- /#page-wrapper -->


### PR DESCRIPTION
Fix for #224 

Enables the autoescape option for the template system, back to its default value of True.

Plugin/machine detail plugin/report html is left alone, as it is safe.

Removes the "safe" tag use for managed item names used for constructing anchor tags' href attribute in the pending (3rd party) updates plugins. If you see broken links in your pending updates plugin display, let us know.