### PR TITLE
Slip the title into ajax view so we can `plugin.filter` just once.

### DIFF
--- a/server/non_ui_views.py
+++ b/server/non_ui_views.py
@@ -70,7 +70,7 @@ def tableajax(request, plugin_name, data, group_type='all', group_id=None):
     plugin_object = process_plugin(plugin_name, group_type, group_id)
     queryset = plugin_object.get_queryset(
         request, group_type=group_type, group_id=group_id)
-    machines, _ = plugin_object.filter_machines(queryset, data)
+    machines, title = plugin_object.filter_machines(queryset, data)
     machines = machines.values('id', 'hostname', 'console_user', 'last_checkin')
 
     if len(order_name) != 0:
@@ -90,6 +90,7 @@ def tableajax(request, plugin_name, data, group_type='all', group_id=None):
     limited_machines = searched_machines[start:(start + length)]
 
     return_data = {}
+    return_data['title'] = title
     return_data['draw'] = int(draw)
     return_data['recordsTotal'] = machines.count()
     return_data['recordsFiltered'] = return_data['recordsTotal']

--- a/server/templates/server/overview_list_all.html
+++ b/server/templates/server/overview_list_all.html
@@ -15,6 +15,8 @@
             },
             "lengthMenu": [[20, 50, 100, 500], [20, 50, 100, 500]],
             "pageLength": {{ page_length }},
+            "initComplete": function ( settings, json) {
+              $('<div/>').html(json.title).prependTo('#title');},
             stateSave: true,
             "order": [2,'desc'],
             "orderMulti": false,
@@ -36,37 +38,20 @@
 {% block content %}
 
 <div class="panel panel-default">
-{% if title %}
-    <div class="panel-heading">
-        {{ title }}
-    </div>
-{% endif %}
-<div class="panel-body">
-    <div class="table-responsive">
-        <table class="groupList table table-striped table-condensed">
-            <thead>
-                <tr>
-                  <th>Machine</th>
-                  <th>User</th>
-                  <th>Latest Run</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for item in machines.all|dictsort:'hostname' %}
-                <tr>
-                    <td>
-                        <a href="{% url 'machine_detail' item.id %}">
-                        {{ item.hostname }}
-                        </a>
-                    </td>
-
-                    <td>{{ item.console_user }}</td>
-                    <td>{{ item.last_checkin|date:"Y-m-d H:i" }}</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
+    <div id="title" class="panel-heading"></div>
+    <div class="panel-body">
+        <div class="table-responsive">
+            <table id="test" class="groupList table table-striped table-condensed">
+                <thead>
+                    <tr>
+                      <th>Machine</th>
+                      <th>User</th>
+                      <th>Latest Run</th>
+                    </tr>
+                </thead>
+                <tbody/>
+            </table>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/server/views.py
+++ b/server/views.py
@@ -92,7 +92,6 @@ def index(request):
 
 @login_required
 def machine_list(request, plugin_name, data, group_type='all', group_id=None):
-    plugin_object = process_plugin(plugin_name, group_type, group_id)
     context = {
         'group_type': group_type,
         'group_id': group_id,

--- a/server/views.py
+++ b/server/views.py
@@ -93,14 +93,10 @@ def index(request):
 @login_required
 def machine_list(request, plugin_name, data, group_type='all', group_id=None):
     plugin_object = process_plugin(plugin_name, group_type, group_id)
-    # Plugin will raise 404 if bad `data` is passed.
-    machines, title = plugin_object.filter_machines(Machine.objects.none(), data)
     context = {
         'group_type': group_type,
         'group_id': group_id,
         'plugin_name': plugin_name,
-        'machines': machines,
-        'title': title,
         'request': request,
         'data': data,
         'page_length': utils.get_setting('datatable_page_length')}


### PR DESCRIPTION
This really cleans up the datatable template; pulled out all of the
stuff that's no longer really being used since datatables are handling
it.

Added the title (which was being just thrown away by the ajax call) into
the data it returns, and then used it in an initComplete func as part of
datatable setup to add the title in the existing place (outside of the
table).