### PR TITLE
Add more features flags and default values to `system_settings.py`

### DIFF
--- a/sal/system_settings.py
+++ b/sal/system_settings.py
@@ -18,6 +18,8 @@ AUTH_PROFILE_MODULE = "sal.UserProfile"
 DISPLAY_NAME = 'Sal'
 MANAGERS = ADMINS
 DEPLOYED_ON_CHECKIN = False
+ADD_TO_ALL_BUSINESS_UNITS = False
+ADD_NEW_MACHINES = True
 INACTIVE_UNDEPLOYED = 0
 SEARCH_FACTS = []
 SEARCH_CONDITIONS = []
@@ -86,6 +88,10 @@ HISTORICAL_FACTS = [
 # How long to keep historical facts around before pruning them.
 HISTORICAL_DAYS = 180
 
+# Facts to be discarded and not saved to the database
+IGNORE_FACTS = []
+
+# Facts to not be displayed on the Machine Information page
 EXCLUDED_FACTS = {
     'sshrsakey',
     'sshfp_rsa',


### PR DESCRIPTION
Given that [Sal's 'Settings' wiki page](https://github.com/salopensource/sal/wiki/Settings) states the following...
>There are defaults set in sal/system_settings.py, but they can be overridden if you choose

... I figured that it might be a good idea to enumerate most every toggle-able feature within the `server_settings.py` file. That said... 

This PR suggests the following changes to `sal/sal/system_settings.py`:
- Add comment explanation (pulled from the wiki page) above `EXCLUDED_FACTS` definition
- Add `IGNORE_FACTS` setting with default value of `[]`
- Add `ADD_TO_ALL_BUSINESS_UNITS` with default value of `False`
- Add `ADD_NEW_MACHINES` with default value of `True`