### PR TITLE
Add psycogreen and use it to patch psycopg for gevent.

### DIFF
--- a/docker/gunicorn_config.py
+++ b/docker/gunicorn_config.py
@@ -25,6 +25,7 @@ max_requests = 1000
 max_requests_jitter = 50
 worker_class = 'gevent'
 
+
 # Patch psycopg to better work with gevent greenlets
 def post_fork(server, worker):
     from psycogreen.gevent import patch_psycopg

--- a/docker/gunicorn_config.py
+++ b/docker/gunicorn_config.py
@@ -2,10 +2,9 @@ import multiprocessing
 from os import getenv
 bind = '127.0.0.1:8001'
 
-workers = multiprocessing.cpu_count() * 3
+workers = multiprocessing.cpu_count() * 2 + 1
 graceful_timeout = 45
 timeout = 60
-threads = multiprocessing.cpu_count() * 3
 
 pidfile = '/var/run/gunicorn.pid'
 
@@ -25,3 +24,8 @@ except Exception:
 max_requests = 1000
 max_requests_jitter = 50
 worker_class = 'gevent'
+
+# Patch psycopg to better work with gevent greenlets
+def post_fork(server, worker):
+    from psycogreen.gevent import patch_psycopg
+    patch_psycopg()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gunicorn==20.0.4
 psycopg2-binary==2.8.5
 gevent==1.5.0
 greenlet==0.4.15
+psycogreen==1.0.2


### PR DESCRIPTION
This PR collects several changes to the gunicorn config to follow
recommended best-practices.

In regards to gunicorn async workers, the design page has this to say
(see https://docs.gunicorn.org/en/stable/design.html#async-workers)
> For full greenlet support applications might need to be adapted. When using, e.g., Gevent and Psycopg it makes sense to ensure psycogreen is installed and setup.

From psycogreen:
> The psycogreen package enables psycopg2 to work with coroutine libraries, using asynchronous calls internally but offering a blocking interface so that regular code can run unmodified.

Therefore, this PR adds psycogreen to `requirements.txt` and patches
psycopg as directed.

This PR sets the gunicorn `workers` value to the recommended default
value.

Also, it drops the `threads` parameter which is actually ignored when
the `worker_class` is `gevent`.

See https://docs.gunicorn.org/en/stable/settings.html#threads
> This setting only affects the Gthread worker type.