### PR TITLE
Re-enable puppetstatus plugin

### DIFF
--- a/server/plugins/puppetstatus/puppetstatus.py
+++ b/server/plugins/puppetstatus/puppetstatus.py
@@ -1,7 +1,8 @@
 from datetime import timedelta
 
 import django.utils.timezone
-from django.db.models import Q
+from django.db.models import (Q, DateTimeField)
+from django.db.models.functions import Cast
 
 import sal.plugin
 
@@ -57,10 +58,12 @@ class PuppetStatus(sal.plugin.Widget):
             today = now - timedelta(hours=24)
             month_ago = today - timedelta(days=30)
 
+            # fact_data is TextField so cast on the fly
             machines = machines.filter(
                 PUPPET_Q,
-                facts__fact_name='last_puppet_run',
-                facts__fact_data__lte=month_ago)
+                facts__fact_name='last_puppet_run').annotate(
+                    last=Cast('facts__fact_data', output_field=DateTimeField())).filter(
+                last__lte=month_ago)
 
         elif data == 'success':
             machines = machines.filter(

--- a/server/views.py
+++ b/server/views.py
@@ -408,7 +408,7 @@ def _get_management_tools(source_names, machine):
         'Apple Software Update': _sus_facts,
         # Want to show data about a management source? Implement a func and
         # change here...
-        'Puppet': _not_implemented_facts,
+        'Puppet': _puppet_facts,
         'Salt': _salt_facts,
         'Chef': _not_implemented_facts,
         'Chrome': _not_implemented_facts,
@@ -456,7 +456,7 @@ def _salt_facts(machine):
 
 
 def _puppet_facts(machine):
-    info_names = ('puppet_version', 'puppet_errors', 'last_puppet_run')
+    info_names = ('puppetversion', 'puppet_errors', 'last_puppet_run')
     rows = _get_management_facts(machine, 'Puppet', info_names)
     return rows
 


### PR DESCRIPTION
The checkin module
https://github.com/salopensource/puppet_checkin_module is responsible
for checking in 'last_puppet_run' and 'puppet_errors' custom facts. We
have to cast the timestamp string to a DateTimeField on the fly to
compare and we also use the built-in fact puppetversion instead of
puppet_version.

Part 2 to fix #403