### PR TITLE
Sort models by year for Machine Models Bar dashboard widget

### DIFF
--- a/server/plugins/machinemodelsbar/machinemodelsbar.py
+++ b/server/plugins/machinemodelsbar/machinemodelsbar.py
@@ -1,5 +1,6 @@
 from collections import Counter
 from operator import itemgetter
+import re
 
 from django.db.models import Q
 
@@ -30,9 +31,15 @@ class MachineModelsBar(sal.plugin.Widget):
                     machine.machine_model, machine.machine_model)
             machine_models[machine_model_friendly] += 1
 
-        data = [{"label": model, "value": machine_models[model]}
-                for model in machine_models]
-        sorted_data = sorted(data, key=itemgetter("value"))
+        def getyear(model):
+            try:
+                return re.findall(r'(\d{4})', model)[0]
+            except IndexError:
+                return 'unknown'
+
+        data = [{"label": model, "value": machine_models[model],
+                 "year": getyear(model)} for model in machine_models]
+        sorted_data = sorted(data, key=itemgetter("year"))
 
         context["data"] = sorted_data
 


### PR DESCRIPTION
We found that sorting machine models by year is very useful to quickly identify old machines that should be upgraded. Bar chart buckets are still counters for individual models and I also didn't touch the labels. Finding the year from the model is just searching for the first 4-digit number in the model and hope for the best. 