### PR TITLE
Add total count per os_family in the Operating System plugin.

### DIFF
--- a/server/plugins/operatingsystem/templates/operatingsystem.html
+++ b/server/plugins/operatingsystem/templates/operatingsystem.html
@@ -11,7 +11,7 @@
     {% for os in os_info %}
       {% if os.1 %}
         <tr>
-          <th>{{ os.0 }}</th>
+          <th>{{ os.0 }}<span class="badge pull-right">{{ os.1|item_sum:'count' }}</span></th>
         </tr>
         {% for item in os.1 %}
             <tr>

--- a/server/templatetags/dashboard_extras.py
+++ b/server/templatetags/dashboard_extras.py
@@ -115,6 +115,14 @@ def sort(data):
 
 
 @register.filter
+def item_sum(seq, name):
+    """Return the sum of an iterable by attribute or key"""
+    if seq and isinstance(seq[0], dict):
+        return sum(i[name] for i in seq)
+    return sum(getattr(i, name) for i in seq)
+
+
+@register.filter
 def dict_lookup(d, k):
     return d[k]
 


### PR DESCRIPTION
This required templatetag modeled after the Jinja one `sum`.