### PR TITLE
Update gevent and python version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Sal Dockerfile
-FROM python:3.7.1
+FROM python:3.9.5-slim-buster
 
 MAINTAINER Graham Gilbert <graham@grahamgilbert.com>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -r setup/requirements.txt
 gunicorn==20.1.0
 psycopg2-binary==2.8.5
-gevent==1.5.0
+gevent==21.1.2
 greenlet==1.1.0
 psycogreen==1.0.2


### PR DESCRIPTION
Python 3.9 min gevent is 20.6.0 and min greenlet is 0.4.16, so let's
just take it to the next versions.