### PR TITLE
Add application inventory detail view for Win32_product

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,12 @@ clean:
 rmi:
 	docker rmi ${DOCKER_USER}/${NAME}
 
+migrations:
+	. venv/bin/activate
+	cp sal/example_settings.py sal/settings.py
+	python manage.py test
+	python manage.py migrate
+
 postgres:
 	docker run --name="${DB_CONTAINER_NAME}" -d -e DB_NAME=$(DB_NAME) -e DB_USER=$(DB_USER) -e DB_PASS=$(DB_PASS) grahamgilbert/postgres
 

--- a/inventory/migrations/0012_auto_20210731_1945.py
+++ b/inventory/migrations/0012_auto_20210731_1945.py
@@ -63,7 +63,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='application',
             name='installdate2',
-            field=models.DateTimeField(blank=True, null=True),
+            field=models.CharField(blank=True, max_length=255, null=True),
         ),
         migrations.AddField(
             model_name='application',

--- a/inventory/models.py
+++ b/inventory/models.py
@@ -16,7 +16,7 @@ class Application(models.Model):
     description = models.CharField(blank=True, null=True, max_length=255)
     identifyingnumber = models.CharField(blank=True, null=True, max_length=255)
     installdate = models.CharField(blank=True, null=True, max_length=255)
-    installdate2 = models.DateTimeField(blank=True, null=True)
+    installdate2 = models.CharField(blank=True, null=True, max_length=255)
     installlocation = models.CharField(blank=True, null=True, max_length=255)
     installstate = models.CharField(blank=True, null=True, max_length=255)
     helplink = models.CharField(blank=True, null=True, max_length=255)

--- a/inventory/templates/inventory/application_detail.html
+++ b/inventory/templates/inventory/application_detail.html
@@ -9,14 +9,86 @@
 {% block inventory_data %}
 	<dl class="dl-horizontal" >
 		<legend><h5 class"text-uppercase">Application Details</h5></legend>
+		<div class="row">
+			<div class="col-xs-6">
 		<dt>Name:</dt>
 		<dd>{{ object.name }} </dd>
 		<dt>Bundle ID:</dt>
 		<dd>{{ object.bundleid }} </dd>
 		<dt>Bundle Name:</dt>
 		<dd>{{ object.bundlename }}</dd>
+		<dt>Assignment Type:</dt>
+		<dd>{{ object.assignmenttype }}</dd>
+		<dt>Caption:</dt>
+		<dd>{{ object.caption }}</dd>
+		<dt>CS Name:</dt>
+		<dd>{{ object.csname }}</dd>
+		<dt>Description:</dt>
+		<dd>{{ object.description }}</dd>
+		<dt>Fix Comments:</dt>
+		<dd>{{ object.fixcomments }}</dd>
+		<dt>Help Link:</dt>
+		<dd>{{ object.helplink }}</dd>
+		<dt>Help Telephone:</dt>
+		<dd>{{ object.helptelephone }}</dd>
+		<dt>Hot Fix ID:</dt>
+		<dd>{{ object.hotfixid }}</dd>
+		<dt>Identifying Number:</dt>
+		<dd>{{ object.identifyingnumber }}</dd>
+		<dt>Install Date:</dt>
+		<dd>{{ object.installdate }}</dd>
+		<dt>Install Date 2:</dt>
+		<dd>{{ object.installdate2 }}</dd>
+		<dt>Installed By:</dt>
+		<dd>{{ object.installedby }}</dd>
+		<dt>Installed On:</dt>
+		<dd>{{ object.installedon }}</dd>
+		<dt>Install Location:</dt>
+		<dd>{{ object.installlocation }}</dd>
+		<dt>Install Source:</dt>
+		<dd>{{ object.installsource }}</dd>
+		<dt>Install State:</dt>
+		<dd>{{ object.installstate }}</dd>
+			</div>
+			<div class="col-xs-6">
+		<dt>Language:</dt>
+		<dd>{{ object.language }}</dd>
+		<dt>Local Package:</dt>
+		<dd>{{ object.localpackage }}</dd>
+		<dt>Package Cache:</dt>
+		<dd>{{ object.packagecache }}</dd>
+		<dt>Package Code:</dt>
+		<dd>{{ object.packagecode }}</dd>
+		<dt>Package Name:</dt>
+		<dd>{{ object.packagename }}</dd>
+		<dt>Product Id:</dt>
+		<dd>{{ object.productid }}</dd>
+		<dt>Reg Company:</dt>
+		<dd>{{ object.regcompany }}</dd>
+		<dt>Reg Owner:</dt>
+		<dd>{{ object.regowner }}</dd>
+		<dt>Service Pack In Effect:</dt>
+		<dd>{{ object.servicepackIneffect }}</dd>
+		<dt>Sku Number:</dt>
+		<dd>{{ object.skunumber }}</dd>
+		<dt>Status:</dt>
+		<dd>{{ object.status }}</dd>
+		<dt>Transforms:</dt>
+		<dd>{{ object.transforms }}</dd>
+		<dt>Url Info About:</dt>
+		<dd>{{ object.urlInfoabout }}</dd>
+		<dt>Url Update Info:</dt>
+		<dd>{{ object.urlupdateInfo }}</dd>
+		<dt>Vendor:</dt>
+		<dd>{{ object.vendor }}</dd>
+		<dt>Version:</dt>
+		<dd>{{ object.version }}</dd>
+		<dt>Word Count:</dt>
+		<dd>{{ object.wordcount }}</dd>
 		<dt>Total Install Count:</dt>
 		<dd><a href="{% url 'inventory_list' application_id=object.id group_type=group_type group_id=group_id %}?field_type=all&field_value=0"><span class="badge">{{ install_count }}</span></a></dd>
+		</div>
+			</div>
 		<br>
 		<legend><h5 class"text-uppercase">Installed Versions</h5></legend>
 		{% for version in versions %}

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -29,10 +29,8 @@ from sal.decorators import (class_login_required, class_access_required, key_aut
 from server.models import BusinessUnit, MachineGroup, Machine
 from utils import text_utils
 
-
 ApplicationTuple = collections.namedtuple(
     'Application', ['name', 'bundleid', 'bundlename', 'install_count'])
-
 
 # Generate the fields dict needed for our CSV row generator.
 APPLICATION_FIELDS = dict(itertools.zip_longest(ApplicationTuple._fields, []))
@@ -182,7 +180,6 @@ class CSVResponseMixin():
 
 
 class InventoryList(Datatable):
-
     # Specifying no source means we cannot sort on this column; however
     # the source value would be the total number of inventoryitem
     # records, NOT the number returned by the get_install_count
@@ -267,7 +264,6 @@ class InventoryListView(DatatableQuerystringMixin, DatatableView, GroupMixin):
 
 
 class ApplicationList(Datatable):
-
     install_count = DisplayColumn(
         "Install Count", source='install_count', processor='get_install_count')
 
@@ -523,8 +519,45 @@ def inventory_submit(request):
                     app, _ = Application.objects.get_or_create(
                         bundleid=item.get("bundleid", ""),
                         name=item.get("name", ""),
-                        bundlename=item.get("CFBundleName", ""))
-                    # skip items in bundleid_ignorelist.
+                        bundlename=item.get("CFBundleName", ""),
+                        # Win32_Package properties
+                        assignmenttype=item.get("assignmenttype", ""),
+                        caption=item.get("caption", ""),
+                        description=item.get("description", ""),
+                        identifyingnumber=item.get("identifyingnumber", ""),
+                        installdate=item.get("installdate", ""),
+                        installdate2=item.get("installdate2", ""),
+                        installlocation=item.get("installlocation", ""),
+                        installstate=item.get("installstate", ""),
+                        helplink=item.get("helplink", ""),
+                        helptelephone=item.get("helptelephone", ""),
+                        installsource=item.get("installsource", ""),
+                        language=item.get("language", ""),
+                        localpackage=item.get("localpackage", ""),
+                        packagecache=item.get("packagecache", ""),
+                        packagecode=item.get("packagecode", ""),
+                        packagename=item.get("packagename", ""),
+                        productid=item.get("productid", ""),
+                        regowner=item.get("regowner", ""),
+                        regcompany=item.get("regcompany", ""),
+                        skunumber=item.get("skunumber", ""),
+                        transforms=item.get("transforms", ""),
+                        urlInfoabout=item.get("urlInfoabout", ""),
+                        urlupdateInfo=item.get("urlupdateInfo", ""),
+                        vendor=item.get("vendor", ""),
+                        wordcount=item.get("wordcount", ""),
+                        version=item.get("version", ""),
+                        # Win32_QFE Properties
+                        status=item.get("status", ""),
+                        csname=item.get("csname", ""),
+                        fixcomments=item.get("fixcomments", ""),
+                        hotfixid=item.get("hotfixid", ""),
+                        installedby=item.get("installedby", ""),
+                        installedon=item.get("installedon", ""),
+                        servicepackIneffect=item.get("servicepackIneffect", ""),
+                    )
+
+                    # TODO what about win32 properties for InventorItem entries?
                     if not item.get('bundleid') in bundleid_ignorelist:
                         i_item = InventoryItem(
                             application=app,


### PR DESCRIPTION
- This request is to add the UI (template, view, etc), 
  changes to support Application Inventory detail view for Win32_Product class.

- In a nutshell make it possible to search for Windows installed applications and HotFixes.

- This PR also fixes an issue with the `installdate2` field for win32_product.

~G