### PR TITLE
Update plugin shebang from pinned 3.8 to Current

### DIFF
--- a/server/plugins/ardinfo/scripts/ard_info.py
+++ b/server/plugins/ardinfo/scripts/ard_info.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import sal

--- a/server/plugins/encryption/scripts/encryption.py
+++ b/server/plugins/encryption/scripts/encryption.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import os

--- a/server/plugins/gatekeeper/scripts/gatekeeper.py
+++ b/server/plugins/gatekeeper/scripts/gatekeeper.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import os

--- a/server/plugins/machinedetailsecurity/scripts/machinedetailsecurity.py
+++ b/server/plugins/machinedetailsecurity/scripts/machinedetailsecurity.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import os

--- a/server/plugins/munkiinfo/scripts/munkiinfo.py
+++ b/server/plugins/munkiinfo/scripts/munkiinfo.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import sys

--- a/server/plugins/sip/scripts/sip.py
+++ b/server/plugins/sip/scripts/sip.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import os

--- a/server/plugins/uptime/scripts/uptime.py
+++ b/server/plugins/uptime/scripts/uptime.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import os

--- a/server/plugins/xprotectversion/scripts/xprotectversion.py
+++ b/server/plugins/xprotectversion/scripts/xprotectversion.py
@@ -1,4 +1,4 @@
-#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3
+#!/usr/local/sal/Python.framework/Versions/Current/bin/python3
 
 
 import pathlib


### PR DESCRIPTION
These plugin scripts were pinned to version `#!/usr/local/sal/Python.framework/Versions/3.8/bin/python3` and that broke when Sal's python changed to 3.9.  Now changed to `#!/usr/local/sal/Python.framework/Versions/Current/bin/python3` in these eight scripts.