### PR TITLE
install supervisor with pip so it uses Python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN apt-get update && \
     libpq-dev \
     python3-dev \
     curl \
-    supervisor \
     libffi-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psycopg2-binary==2.8.5
 gevent==21.1.2
 greenlet==1.1.0
 psycogreen==1.0.2
+supervisor==4.2.4


### PR DESCRIPTION
I noticed that supervisord was running with /usr/bin/python2 in the latest release. Seemed like a good idea to switch to a pip3-installed supervisor that runs with Python3. I have only tested this locally.