### PR TITLE
Plugins: fix reading Xprotect version on newer macOS version

### DIFF
--- a/server/plugins/xprotectversion/scripts/xprotectversion.py
+++ b/server/plugins/xprotectversion/scripts/xprotectversion.py
@@ -1,6 +1,4 @@
 #!/usr/local/sal/Python.framework/Versions/Current/bin/python3
-
-
 import pathlib
 import plistlib
 import os
@@ -8,11 +6,10 @@ import os
 import sal
 
 
-
 def xprotect_version():
     try:
         darwin_ver = int(os.uname().release.split('.')[0])
-    except:
+    except (ValueError, AttributeError):
         return 'Not supported'
     if darwin_ver >= 20:  # Big Sur 11.x
         xprotect = '/Library/Apple/System/Library/CoreServices/XProtect.bundle/Contents/Info.plist'
@@ -24,13 +21,13 @@ def xprotect_version():
     if plist_path.exists():
         plist = plistlib.loads(plist_path.read_bytes())
         return str(int(plist[key]))
-    else:
-        return 'Not supported'
+    return 'Not supported'
 
 
 def main():
     version = xprotect_version()
     sal.add_plugin_results('XprotectVersion', {'Version': version})
+
 
 if __name__ == '__main__':
     main()

--- a/server/plugins/xprotectversion/scripts/xprotectversion.py
+++ b/server/plugins/xprotectversion/scripts/xprotectversion.py
@@ -3,21 +3,34 @@
 
 import pathlib
 import plistlib
+import os
 
 import sal
 
 
-def main():
-    plist_path = pathlib.Path(
-        '/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/XProtect.meta.plist')
+
+def xprotect_version():
+    try:
+        darwin_ver = int(os.uname().release.split('.')[0])
+    except:
+        return 'Not supported'
+    if darwin_ver >= 20:  # Big Sur 11.x
+        xprotect = '/Library/Apple/System/Library/CoreServices/XProtect.bundle/Contents/Info.plist'
+        key = 'CFBundleShortVersionString'
+    else:
+        xprotect = '/System/Library/CoreServices/CoreTypes.bundle/Contents/Resources/XProtect.meta.plist'
+        key = 'Version'
+    plist_path = pathlib.Path(xprotect)
     if plist_path.exists():
         plist = plistlib.loads(plist_path.read_bytes())
-        version = str(plist['Version'])
+        return str(int(plist[key]))
     else:
-        version = 'Not supported'
+        return 'Not supported'
 
+
+def main():
+    version = xprotect_version()
     sal.add_plugin_results('XprotectVersion', {'Version': version})
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
xprotect info plist moved to a different location starting with macOS 11.x

Should fix #420 