### PR TITLE
circle: replace / in CIRCLE_BRANCH to use as docker tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,13 +66,13 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: docker build -t macadmins/sal:$CIRCLE_BRANCH .
+      - run: docker build -t macadmins/sal:${CIRCLE_BRANCH//\//_} .
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
-      - run: docker push macadmins/sal:$CIRCLE_BRANCH
+      - run: docker push macadmins/sal:${CIRCLE_BRANCH//\//_}
       - run: apk update
       - run: apk add python2 py2-pip
       - run: pip install requests
-      - run: python remote_build.py $CIRCLE_BRANCH
+      - run: python remote_build.py ${CIRCLE_BRANCH//\//_}
 
   build_tag:
     docker:


### PR DESCRIPTION
PR jobs are currently [failing](https://app.circleci.com/pipelines/github/salopensource/sal/116/workflows/3750a4c8-5704-48ba-8db3-a4fc2f0eb20d/jobs/1158) because `CIRCLE_BRANCH` contains a `/`, which is not allowed as a docker tag. Trivial change to replace all occurances of `/` with `_` should "fix" this.