### PR TITLE
circle: new convenience image and latest python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/python:3.7.1
+      - image: cimg/python:3.7
 
     working_directory: ~/repo
 


### PR DESCRIPTION
More trivial changes incoming :sweat_smile: 

Circle [warns](https://app.circleci.com/pipelines/github/salopensource/sal/115/workflows/639a3370-6679-4d2c-8469-841d39597bf1/jobs/1156) about using [deprecated base images](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034).

I also propose to use python `3.7` instead of a pinned `3.7.1` to test against latest python 3.7, but I guess that's a design decision for the repo.