### PR TITLE
Add Django HealthCheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,4 @@ workflows:
             tags:
               only: /.*/
             branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
-
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.9.16
 
     working_directory: ~/repo
 
@@ -46,7 +46,7 @@ jobs:
           destination: test-reports
   build_latest:
     docker:
-      - image: docker:18.06.1-ce-git
+      - image: docker:20.10.23-git
 
     steps:
       - checkout
@@ -60,7 +60,7 @@ jobs:
 
   build_branch:
     docker:
-      - image: docker:18.06.1-ce-git
+      - image: docker:20.10.23-git
 
     steps:
       - checkout
@@ -76,7 +76,7 @@ jobs:
 
   build_tag:
     docker:
-      - image: docker:18.06.1-ce-git
+      - image: docker:20.10.23-git
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,4 +117,6 @@ workflows:
             tags:
               only: /.*/
             branches:
-              ignore: /.*/
+              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+              ignore: /pull\/[0-9]+/
+

--- a/sal/system_settings.py
+++ b/sal/system_settings.py
@@ -203,6 +203,7 @@ INSTALLED_APPS = (
     "search",
     "rest_framework",
     "django_filters",
+    'health_check',
 )
 
 

--- a/sal/urls.py
+++ b/sal/urls.py
@@ -24,6 +24,8 @@ urlpatterns = [
     path('licenses/', include('licenses.urls')),
     path('catalog/', include('catalog.urls')),
     path('profiles/', include('profiles.urls')),
+    path('healthcheck/', include('health_check.urls')),
+
 ]
 
 if settings.DEBUG:

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -3,6 +3,7 @@ django-bootstrap3==12.0.3
 django-debug-toolbar==3.2.1
 django-filter==2.4.0
 djangorestframework==3.11.2
+django-health-check==3.17.0
 idna==2.7
 # Required for DRF
 markdown==3.2.1


### PR DESCRIPTION
The following adds https://pypi.org/project/django-health-check/ in it's default configuration. 

This is to provide a http endpoint which will return an unauthenticated 200 code on a healthy status.

The specific use-case this is used personally is to provide a GKE L7 ingress compatible readiness check endpoint.


This includes drive by fixes for CI 