### PR TITLE
Remove incorrect gating of all group App Inventory to only GA users.

### DIFF
--- a/server/templates/server/index.html
+++ b/server/templates/server/index.html
@@ -76,9 +76,7 @@ $( document ).ready(function() {
             {% endif %}
         {% endif %}
     {% endif %}
-    {% if user.userprofile.level == 'GA' %}
     <li><a href="{% url 'application_list' group_type='all' group_id='0' %}"><i class="fa fa-list-alt fa-fw"></i> Application Inventory</a></li>
-    {% endif %}
     <li class="active">
         <a href="#"><i class="fa fa-building fa-fw"></i> Business Units<span class="fa arrow"></span></a>
         <ul class="nav nav-second-level">


### PR DESCRIPTION
This PR removes the jinja conditional requiring a user be GA to see a link to the application inventory on the "All" (global) dashboard. All users have access to the application inventory, and results in the inventory query are filtered by the user's BU access as part of the inventory list view, so this conditional is just a mistake.

See #444
