### PR TITLE
Fix filename generation exception for app inventory csv

### DIFF
--- a/inventory/views.py
+++ b/inventory/views.py
@@ -180,7 +180,7 @@ class CSVResponseMixin():
     header = []
 
     def get_csv_filename(self):
-        identifier = "_" + "_".join(self.components) if self.components else ""
+        identifier = "_" + "_".join(str(c) for c in self.components) if self.components else ""
         filename = "%s%s%s" % (self.csv_filename, identifier, self.csv_ext)
         return filename
 


### PR DESCRIPTION
This causes an exception otherwise, because machine group and business
unit ID come across as `int`.
