### PR TITLE
Fix DataTables warning on manage_users.html

### DIFF
--- a/server/templates/server/manage_users.html
+++ b/server/templates/server/manage_users.html
@@ -32,6 +32,7 @@
           <th>Username</th>
           <th>User Level</th>
           <th></th>
+          <th></th>
         </tr>
     </thead>
         <tbody>

--- a/server/templates/server/settings.html
+++ b/server/templates/server/settings.html
@@ -3,20 +3,6 @@
 {% load dashboard_extras %}
 {% load bootstrap3 %}
 
-{% block script %}
-<script type="text/javascript" charset="utf-8">
-    $(document).ready(function() {
-        $('.groupList').DataTable({
-            "lengthMenu": [[20, 50, -1], [20, 50, "All"]],
-            'columnDefs': [{
-                'orderable': false,
-                'targets': [-1, -2] /* 1st one, start by the right */
-            }]
-        });
-    } );
-</script>
-{% endblock %}
-
 {% block nav %}
         <li><a href="{% url 'home' %}"><i class="fa-chevron-left fa fa-fw"></i> Back</a></li>
         {% if user.is_staff %}


### PR DESCRIPTION
DataTables added this warning [on Oct 22, 2022](https://github.com/DataTables/DataTablesSrc/commit/7abe192c08f1df1ddfba15fb62e57f2a613422c3) (later released in DataTables >=1.13.2):

![Screenshot 2023-10-12 at 5 05 51 PM](https://github.com/salopensource/sal/assets/20032435/b512de52-f257-4cf3-9444-05133926b174)

It occurs when the header column count != a row's column count. It started occurring on Sal's manage_users.html after DataTables was [updated to 1.13.5](https://github.com/salopensource/sal/commit/687d707a1239d779ec57354bf462dbd0657a9338#diff-690b81fad8df2a1f1ce37c846641d9247e3472d244f17039d2910a5ed0c98d5e). It does not occur if this commit is reverted.

It appears no other table triggers the warning. I checked tables in these templates:

```
✗ grep "DataTable(" -r ./**/templates/*
./licenses/templates/licenses/index.html:        $('.groupList').DataTable({
./server/templates/server/plugins.html:    $('.groupList').DataTable({
./server/templates/server/machine_detail_plugins.html:    $('.groupList').DataTable({
./server/templates/server/manage_users.html:        $('.groupList').DataTable({
./server/templates/server/machine_detail_facts.html:        $('.groupList').DataTable({
./server/templates/server/api_keys.html:        $('.groupList').DataTable({
./server/templates/server/reports.html:    $('.groupList').DataTable({
```

I noticed the invocation in `server/templates/server/settings.html` doesn't appear to be used -  there's no table rendered on the page (and no other template extends settings.html per `grep 'extends "settings.html"' -r .`). Deleted it. Lmk if this is incorrect, ofc.

Edit: I don't think this CI error is related to the delta:

![Screenshot 2023-10-12 at 5 48 23 PM](https://github.com/salopensource/sal/assets/20032435/aae9bfa2-9130-4c5f-9ce4-234d57900a69)
