### PR TITLE
Force the Apple device image to be 120x120

### DIFF
--- a/server/templates/server/machine_detail.html
+++ b/server/templates/server/machine_detail.html
@@ -41,7 +41,7 @@ $( document ).ready(function() {
   <div class="col-md-5">
     <p style="text-align: center;">
       {% if machine.os_family == 'Darwin' %}
-      <img src='https://km.support.apple.com/kb/securedImage.jsp?configcode={{machine.serial|slice:"8:" }}&size=120x120'>
+      <img src='https://km.support.apple.com/kb/securedImage.jsp?configcode={{machine.serial|slice:"8:" }}&size=120x120' height="120" width="120" alt="macOS" />
       {% elif machine.os_family == 'ChromeOS' %}
       <img src="{% static 'img/Chrome.png' %}" height="120" width="120" alt="Chrome OS"/>
       {% else %}


### PR DESCRIPTION
Just messing around, I wasn't able to hand-fuzz the request params to
make this work for the new randomized serial numbers, so I just clamped
them to 120x120 to avoid 960px images throwing off the layout.

I also added alt text and a tag /
