### PR TITLE
Implement AWS IAM-based Authentication to RDS Postgres

### DIFF
--- a/docker/settings.py
+++ b/docker/settings.py
@@ -31,6 +31,14 @@ if 'MEMCACHED_PORT_11211_TCP_ADDR' in os.environ:
 host = None
 port = None
 
+if 'DB_HOST' in os.environ:
+    host = os.environ.get('DB_HOST')
+    port = os.environ.get('DB_PORT')
+
+elif 'DB_PORT_5432_TCP_ADDR' in os.environ:
+    host = os.environ.get('DB_PORT_5432_TCP_ADDR')
+    port = os.environ.get('DB_PORT_5432_TCP_PORT', '5432')
+
 if host and port:
     DATABASES = {
         'default': {

--- a/docker/settings.py
+++ b/docker/settings.py
@@ -31,13 +31,18 @@ if 'MEMCACHED_PORT_11211_TCP_ADDR' in os.environ:
 host = None
 port = None
 
-if 'DB_HOST' in os.environ:
-    host = os.environ.get('DB_HOST')
-    port = os.environ.get('DB_PORT')
+if 'DB_USER' in os.environ:
+    if 'DB_HOST' in os.environ:
+        host = os.environ.get('DB_HOST')
+        port = os.environ.get('DB_PORT')
 
-elif 'DB_PORT_5432_TCP_ADDR' in os.environ:
-    host = os.environ.get('DB_PORT_5432_TCP_ADDR')
-    port = os.environ.get('DB_PORT_5432_TCP_PORT', '5432')
+    elif 'DB_PORT_5432_TCP_ADDR' in os.environ:
+        host = os.environ.get('DB_PORT_5432_TCP_ADDR')
+        port = os.environ.get('DB_PORT_5432_TCP_PORT', '5432')
+
+    else:
+        host = 'db'
+        port = '5432'
 
 if host and port:
     DATABASES = {

--- a/docker/settings.py
+++ b/docker/settings.py
@@ -34,7 +34,7 @@ port = None
 if 'DB_USER' in os.environ:
     if 'DB_HOST' in os.environ:
         host = os.environ.get('DB_HOST')
-        port = os.environ.get('DB_PORT')
+        port = os.environ.get('DB_PORT', '5432')
 
     elif 'DB_PORT_5432_TCP_ADDR' in os.environ:
         host = os.environ.get('DB_PORT_5432_TCP_ADDR')

--- a/docker/settings.py
+++ b/docker/settings.py
@@ -31,19 +31,6 @@ if 'MEMCACHED_PORT_11211_TCP_ADDR' in os.environ:
 host = None
 port = None
 
-if 'DB_USER' in os.environ:
-    if 'DB_HOST' in os.environ:
-        host = os.environ.get('DB_HOST')
-        port = os.environ.get('DB_PORT', '5432')
-
-    elif 'DB_PORT_5432_TCP_ADDR' in os.environ:
-        host = os.environ.get('DB_PORT_5432_TCP_ADDR')
-        port = os.environ.get('DB_PORT_5432_TCP_PORT', '5432')
-
-    else:
-        host = 'db'
-        port = '5432'
-
 if host and port:
     DATABASES = {
         'default': {
@@ -53,5 +40,35 @@ if host and port:
             'PASSWORD': os.environ['DB_PASS'],
             'HOST': host,
             'PORT': port,
+        }
+    }
+
+if 'AWS_IAM' in os.environ:
+    import requests
+    cert_bundle_url = 'https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem'
+    cert_target_path = '/etc/ssl/certs/global-bundle.pem'
+
+    response = requests.get(cert_bundle_url)
+    if response.status_code == 200:
+        os.makedirs(os.path.dirname(cert_target_path), exist_ok=True)
+
+        with open(cert_target_path, 'wb') as file:
+            file.write(response.content)
+        print(f"AWS RDS cert bundle successfully downloaded and saved to {cert_target_path}")
+    else:
+        print(f"Failed to download AWS RDS cert bundle, status code: {response.status_code}")
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django_iam_dbauth.aws.postgresql',
+            'NAME': os.environ['DB_NAME'],
+            'USER': os.environ['DB_USER'],
+            'HOST': os.environ['DB_HOST'],
+            'PORT': os.environ['DB_PORT'],
+            'OPTIONS' : {
+                'region_name': os.environ['AWS_RDS_REGION'],
+                'sslmode': 'verify-full',
+                'sslrootcert': '/etc/ssl/certs/global-bundle.pem',
+                'use_iam_auth': True,
+            }
         }
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ gevent==21.1.2
 greenlet==1.1.0
 psycogreen==1.0.2
 supervisor==4.2.4
+django-iam-dbauth==0.1.4


### PR DESCRIPTION
**Overview:** 
This PR will implement the ability for Sal to authenticate against an AWS RDS database without a password by using AWS IAM Authentication (by way of an a locally generated AWS RDS authentication token). The mechanics of token generation are handled by [the `django-iam-dbauth` custom database wrapper](https://github.com/labd/django-iam-dbauth)).

**Design Decisions:**
Going off of [this convo](https://macadmins.slack.com/archives/C061B9XGS/p1721136367320109?thread_ts=1721132429.846779&cid=C061B9XGS), I initially started to roll-my-own solution using `boto3` but after testing `django-iam-dbauth`, I deemed this simple wrapper to be pretty solid (plus the mechanics of short-lived token handling/[re-]generation within Django is kind of annoying).

Additionally, I wanted this to be a no-op change for those that wished to continue using user/password-based authentication; that was achieved by way of gating all IAM-based auth configs on the existence of `AWS_IAM` env var.

**Code Changes:** 
I believe these changes to be pretty straightforward but here's a rundown, anyway:
* Adds latest-version-pinned `django-iam-dbauth` to `requirements.txt`
* Conditionally enables ☝️ `django-iam-dbauth` database enging/backend auth mechs (toggled via `AWS_IAM` env var existence)
  * When ☝️ is enabled:
    * The global [AWS RDS global certificate bundle](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions) is downloaded to the canonical path of `/etc/ssl/certs/global-bundle.pem`
    * Django settings are reconfigured for use with `django_iam_dbauth.aws.postgresql` `engine` type
    * The AWS RDS region config for `django_iam_dbauth.aws.postgresql` is set via the `AWS_RDS_REGION` env var
    * `sslmode` gets set to `verify-full` so that the database-server-hostname-to-presented-certificate-name validation checks occur

*How It Works:* 
In order to migrate a Sal deployment from user/password-based to IAM-based RDS authentication, the following conditions will need to be met/actions need to be taken:

1. "IAM DB authentication" will need to be enabled on the RDS database
2. `rds_iam` role will need to be granted to the authenticating Postgres user
   * n.b. it is advisable to make a net-new, non-"Master username" user which will solely be used for IAM authentication; this user will need the same exact database roles/permissions as the original database user
     * Example: `CREATE USER mycoolsaliamuser WITH LOGIN; GRANT rds_iam to mycoolsaliamuser; GRANT rds_superuser to mycoolsaliamuser; GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO mycoolsaliamuser;`
4. `AWS_IAM` must be set to `"true"` within the container environment
5. `AWS_RDS_REGION` must be set (to the region string where your database lives; i.e. `"us-west-2"`) within the container environment
6. Sal container must be able to perform `AssumeRole` against an IAM Role that has an attached policy permitting the `rds-db:connect` action for your target database (as the container must have a valid STS session token in order for the `django-iam-dbauth` custom database wrapper to generate an RDS authentication token).

**Example IAM Policy:**
```json
{
    "Statement": [
        {
            "Action": [
                "rds-db:connect"
            ],
            "Effect": "Allow",
            "Resource": [
                "arn:aws:rds-db:<YourRDSRegion>:<YourAWSAccountID>:dbuser:<YourRDSDatabaseResourceID>/<YourPostgresUserForIAMAuth>"
            ]
        },
        {
            "Action": [
                "rds:DescribeDBInstances",
                "rds:DescribeDBClusters",
                "rds:DescribeDBEngineVersions"
            ],
            "Effect": "Allow",
            "Resource": "*"
        }
    ],
    "Version": "2012-10-17"
}
```

**Testing:** 
This PR's changes was tested against an internal fork of sal-saml (whose sole changes are those outlined in #462 by @jholt13); that said, it would probably be ideal to land his PR before this one. The changes outlined in this PR have been working smoothly in our dev environment and I believe this is ready for prime-time. Since I was testing against sal-saml, I've also gone ahead and opened PR [#22](https://github.com/salopensource/sal-saml/pull/22) to update that repository with these same changes.